### PR TITLE
The follwing dependencies were aligned to EAP 6.1.1 GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <version.org.apache.commons.compress>1.0</version.org.apache.commons.compress>
     <version.org.apache.commons.exec>1.0.1</version.org.apache.commons.exec>
     <version.org.apache.commons.math>2.2</version.org.apache.commons.math>
-    <version.org.apache.cxf>2.6.6</version.org.apache.cxf>
+    <version.org.apache.cxf>2.6.8</version.org.apache.cxf>
     <version.org.apache.ftpserver>1.0.6</version.org.apache.ftpserver>
     <version.org.apache.helix>0.6.1-incubating</version.org.apache.helix>
     <version.org.apache.karaf>2.3.0</version.org.apache.karaf>
@@ -168,10 +168,10 @@
     <version.org.eclipse.jgit>2.1.0.201209190230-r</version.org.eclipse.jgit>
     <version.org.freemarker>2.3.19</version.org.freemarker>
     <version.org.glassfish>3.1.2</version.org.glassfish>
-    <version.org.hibernate>4.2.0.Final</version.org.hibernate>
+    <version.org.hibernate>4.2.0.SP1</version.org.hibernate>
     <version.org.hibernate.validator>4.3.1.Final</version.org.hibernate.validator>
     <version.org.hibernate.javax.persistence>1.0.1.Final</version.org.hibernate.javax.persistence>
-    <version.org.hornetq>2.3.1.Final</version.org.hornetq>
+    <version.org.hornetq>2.3.5.Final</version.org.hornetq>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>
     <version.org.javassist>3.15.0-GA</version.org.javassist>
     <version.org.jbpm.jbpm5.jbpmmigration>0.11</version.org.jbpm.jbpm5.jbpmmigration>
@@ -180,7 +180,7 @@
     <version.org.jboss.arquillian.container.weld>1.0.0.CR5</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.as>7.2.0.Final</version.org.jboss.as>
     <version.org.jboss.errai>2.3.2.Final</version.org.jboss.errai>
-    <version.org.jboss.ironjacamar>1.0.17.Final</version.org.jboss.ironjacamar>
+    <version.org.jboss.ironjacamar>1.0.19.Final</version.org.jboss.ironjacamar>
     <version.org.jboss.logging>3.1.2.GA</version.org.jboss.logging>
     <version.org.jboss.netty>3.2.6.Final</version.org.jboss.netty>
     <version.org.jboss.resteasy>2.3.6.Final</version.org.jboss.resteasy>
@@ -194,7 +194,7 @@
     <version.org.jboss.solder>3.2.1.Final</version.org.jboss.solder>
     <version.org.jboss.weld>1.1.13.Final</version.org.jboss.weld>
     <version.org.jboss.weld.spi>1.1.Final</version.org.jboss.weld.spi>
-    <version.org.jdom>1.1.3</version.org.jdom>
+    <version.org.jdom>1.1.2</version.org.jdom>
     <version.org.jfree.jfreechart>1.0.14</version.org.jfree.jfreechart>
     <version.org.json>20090211</version.org.json>
     <version.org.mockito>1.9.0</version.org.mockito>


### PR DESCRIPTION
The follwing dependencies were aligned to EAP 6.1.1 GA

 version.org.apache.cxf-> 2.6.8  upgraded
 version.org.hibernate-> 4.2.0.SP1 upgraded
 version.org.hornetq -> 2.3.5.Final upgraded
 version.org.jboss.ironjacamar -> 1.0.19.Final upgraded
 version.org.jdom - > 1.1.2 downgraded from 1.1.3 to 1.1.2

obs: in all cases only minor version numbers were changed
