### PR TITLE
Errai version was changed to  2.4.0.CR1 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <version.org.jboss.arquillian.container.glassfish>1.0.0.CR3</version.org.jboss.arquillian.container.glassfish>
     <version.org.jboss.arquillian.container.weld>1.0.0.CR5</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.as>7.2.0.Final</version.org.jboss.as>
-    <version.org.jboss.errai>2.3.2.Final</version.org.jboss.errai>
+    <version.org.jboss.errai>2.4.0.CR1</version.org.jboss.errai>
     <version.org.jboss.ironjacamar>1.0.19.Final</version.org.jboss.ironjacamar>
     <version.org.jboss.logging>3.1.2.GA</version.org.jboss.logging>
     <version.org.jboss.netty>3.2.6.Final</version.org.jboss.netty>
@@ -1157,6 +1157,11 @@
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-jboss-as-support</artifactId>
+        <version>${version.org.jboss.errai}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Errai version was changed to 2.4.0.CR1 because It's the version we are using in all workbenchs, e.g. kie-wb, kie-drools-wb, etc.

When this change is applied we don't need any more the errai stuff the kie-parent-with-dependencies file that was set to override the errai version.

The changes must be processed in order, first this file, and then the kie-parent-wigh-dependencies file.
