### PR TITLE
Changing org.codehaus.btm:btm version to 3.0.0.Alpha1-jbossorg-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.beanshell>1.3.0</version.org.beanshell>
     <version.org.cobogw.gwt>1.0</version.org.cobogw.gwt>
-    <version.org.codehaus.btm>3.0.0-20130426.133011-3</version.org.codehaus.btm>
+    <version.org.codehaus.btm>3.0.0.Alpha1-jbossorg-1</version.org.codehaus.btm>
     <version.org.codehaus.jackson>1.9.9</version.org.codehaus.jackson>
     <version.org.codehaus.janino>2.5.16</version.org.codehaus.janino>
     <version.org.codehaus.jettison>1.3.1</version.org.codehaus.jettison>


### PR DESCRIPTION
I've deployed a "stable" version of org.codehaus.btm:btm:3.0.0-SNAPSHOT here: 
https://repository.jboss.org/nexus/content/groups/public/org/codehaus/btm/btm/3.0.0.Alpha1-jbossorg-1/

Please merge this so that we can make product and QE happy! :)
