### PR TITLE
moved to bitornix final version (2.1.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.beanshell>1.3.0</version.org.beanshell>
     <version.org.cobogw.gwt>1.0</version.org.cobogw.gwt>
-    <version.org.codehaus.btm>3.0.0.Alpha1-jbossorg-1</version.org.codehaus.btm>
+    <version.org.codehaus.btm>2.1.4</version.org.codehaus.btm>
     <version.org.codehaus.jackson>1.9.9</version.org.codehaus.jackson>
     <version.org.codehaus.janino>2.5.16</version.org.codehaus.janino>
     <version.org.codehaus.jettison>1.3.1</version.org.codehaus.jettison>


### PR DESCRIPTION
bitronix has been enhanced to fix the issue that was introduced by move to hibernate 4.2 and new release is out now so we no longer need to rely on snapshot.
