### PR TITLE
bump version of beanshell to 2.0b5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <version.org.apache.ws.commons.axiom>1.2.8</version.org.apache.ws.commons.axiom>
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.apache.xmlgraphics.batik>1.7</version.org.apache.xmlgraphics.batik>
-    <version.org.beanshell>1.3.0</version.org.beanshell>
+    <version.org.beanshell>2.0b5</version.org.beanshell>
     <version.org.cobogw.gwt>1.0</version.org.cobogw.gwt>
     <version.org.codehaus.btm>2.1.4</version.org.codehaus.btm>
     <version.org.codehaus.jackson>1.9.9</version.org.codehaus.jackson>


### PR DESCRIPTION
Move to current version packaged with FSW 6.
