### PR TITLE
Removed Lucene artifacts which were introduced for versions >= 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -973,16 +973,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-analyzers-common</artifactId>
-        <version>${version.org.apache.lucene}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-codecs</artifactId>
-        <version>${version.org.apache.lucene}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-queryparser</artifactId>
         <version>${version.org.apache.lucene}</version>
       </dependency>


### PR DESCRIPTION
This PR removes 2 Lucene artifacts which don't exist for `3.6.2` and were introduced in 4.x.
