### PR TITLE
Add gwt-maven-plugin in community bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,4 +281,16 @@
     <version.xmlunit>1.3</version.xmlunit>
   </properties>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>gwt-maven-plugin</artifactId>
+          <version>${version.com.google.gwt}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
Manage the gwt-maven-plugin version to the same version as gwt artifacts which already defines in community bom.

I have seen the following error during product build:

[INFO] --- gwt-maven-plugin:2.5.1:compile (gwt-compile) @ uberfire-webapp ---
[WARNING] You're project declares dependency on gwt-user 2.5.0. This plugin is designed for at least gwt version 2.5.1
[WARNING] You're project declares dependency on gwt-user 2.5.0. This plugin is designed for at least gwt version 2.5.1
..
