### PR TITLE
Updating helix to 0.6.2-incubating because of HELIX-257

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <version.org.apache.commons.ssl>0.3.9</version.org.apache.commons.ssl>
     <version.org.apache.cxf>2.6.8</version.org.apache.cxf>
     <version.org.apache.ftpserver>1.0.6</version.org.apache.ftpserver>
-    <version.org.apache.helix>0.6.1-incubating</version.org.apache.helix>
+    <version.org.apache.helix>0.6.2-incubating</version.org.apache.helix>
     <version.org.apache.httpcomponents.httpclient>4.2.1</version.org.apache.httpcomponents.httpclient>
     <version.org.apache.karaf>2.3.0</version.org.apache.karaf>
     <version.org.apache.lucene>3.6.2</version.org.apache.lucene>


### PR DESCRIPTION
See:     
- [HELIX-257](https://issues.apache.org/jira/browse/HELIX-257): Upgrade Restlet to 2.1.4 - due security flaw
- [0.6.2-incubating release notes](http://helix.incubator.apache.org/releasenotes/release-0.6.2-incubating.html)

Also: 
- [HELIX-258](https://issues.apache.org/jira/browse/HELIX-258): Upgrade Apache Camel due to CVE-2013-4330
