### PR TITLE
Removed classifier `classes` from `chemistry-opencmis-server-bindings`.

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -687,7 +687,6 @@
         <groupId>org.apache.chemistry.opencmis</groupId>
         <artifactId>chemistry-opencmis-server-bindings</artifactId>
         <version>${version.org.apache.chemistry}</version>
-        <classifier>classes</classifier>
       </dependency>
       <dependency>
         <groupId>org.apache.chemistry.opencmis</groupId>


### PR DESCRIPTION
This has been removed in the current 0.10.0 version.
