### PR TITLE
Update Errai version from 2.4.1.Final to 2.4.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <version.org.jboss.arquillian.container.glassfish>1.0.0.CR3</version.org.jboss.arquillian.container.glassfish>
     <version.org.jboss.arquillian.container.weld>1.0.0.CR5</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.as>7.2.0.Final</version.org.jboss.as>
-    <version.org.jboss.errai>2.4.1.Final</version.org.jboss.errai>
+    <version.org.jboss.errai>2.4.3.Final</version.org.jboss.errai>
     <version.org.jboss.ironjacamar>1.0.19.Final</version.org.jboss.ironjacamar>
     <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
     <version.org.jboss.jbossts.jbossxts>4.17.7.Final</version.org.jboss.jbossts.jbossxts>


### PR DESCRIPTION
This new version is just for bug fixes, here a complete list them:
https://issues.jboss.org/browse/ERRAI-673?jql=project%20%3D%20ERRAI%20AND%20fixVersion%20in%20(%222.4.2.Final%22%2C%20%222.4.3.Final%22)

Note: ERRAI-671 - Build/Compilation hangs when running with only one CPU is very annoying, we see this error all the time on our CI and on our developer's machine as well.
