### PR TITLE
Bump the version of GWT to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <version.com.google.code.gin>1.0</version.com.google.code.gin>
     <version.com.google.code.gson>1.7.2</version.com.google.code.gson>
     <version.com.google.guava>13.0.1</version.com.google.guava>
-    <version.com.google.gwt>2.5.0</version.com.google.gwt>
+    <version.com.google.gwt>2.5.1</version.com.google.gwt>
     <version.com.google.javascript.closure-compiler>r1741</version.com.google.javascript.closure-compiler>
     <version.com.google.protobuf>2.5.0</version.com.google.protobuf>
     <version.com.h2database>1.3.168</version.com.h2database>


### PR DESCRIPTION
There is a problem when using Errai Data Binding with GWT 2.5.0 (only in Dev Mode) that was fixed in GWT 2.5.1.  I would therefore like to upgrade.
