### PR TITLE
Upgrade commons-math from 2.2 to 3.2

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -714,8 +714,8 @@
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
-        <artifactId>commons-math</artifactId>
-        <version>${version.org.apache.commons.math}</version>
+        <artifactId>commons-math3</artifactId>
+        <version>${version.org.apache.commons.math3}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <version.org.apache.chemistry>0.10.0</version.org.apache.chemistry>
     <version.org.apache.commons.compress>1.4.1</version.org.apache.commons.compress>
     <version.org.apache.commons.exec>1.0.1</version.org.apache.commons.exec>
-    <version.org.apache.commons.math>2.2</version.org.apache.commons.math>
+    <version.org.apache.commons.math3>3.2</version.org.apache.commons.math3>
     <version.org.apache.commons.ssl>0.3.9</version.org.apache.commons.ssl>
     <version.org.apache.cxf>2.6.8</version.org.apache.cxf>
     <version.org.apache.ftpserver>1.0.6</version.org.apache.ftpserver>


### PR DESCRIPTION
Note that the artifactId and version string of the dependency changed.
