### PR TITLE
Added version (4.0.1.Final) for hibernate-commons-annotations

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1291,6 +1291,11 @@
         <version>${version.org.hibernate.validator}</version>
       </dependency>
       <dependency>
+        <groupId>org.hibernate.common</groupId>
+        <artifactId>hibernate-commons-annotations</artifactId>
+        <version>${version.org.hibernate.commons.annotations}</version>
+      </dependency>
+      <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-search-engine</artifactId>
         <version>${version.org.hibernate.search}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
     <version.org.hibernate.search>4.3.0.Final</version.org.hibernate.search>
     <version.org.hibernate.validator>4.3.1.Final</version.org.hibernate.validator>
     <version.org.hibernate.javax.persistence>1.0.1.Final</version.org.hibernate.javax.persistence>
+    <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
     <version.org.hornetq>2.3.5.Final</version.org.hornetq>
     <version.org.infinispan>5.2.7.Final</version.org.infinispan>
     <!--This needs to be in sync with JUnit-->


### PR DESCRIPTION
4.0.1.Final is the version of the module used in jboss EAP and, AFAIK, the version used with hibernate-core/-entitymanager 4.2.0.SP1. 
