### PR TITLE
On the itext dependency exclude the bouncycaste dependencies 

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -211,6 +211,17 @@
         <groupId>com.lowagie</groupId>
         <artifactId>itext</artifactId>
         <version>${version.com.lowagie.itext}</version>
+        <exclusions>
+          <!-- The bouncycastle dependencies should be optional=true in itext's pom -->
+          <exclusion>
+            <groupId>bouncycastle</groupId>
+            <artifactId>bcmail-jdk14</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>bouncycastle</groupId>
+            <artifactId>bcprov-jdk14</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
because they should have been optional=true in the first place.
They are dead weight and they pose security concerns.
