### PR TITLE
Update versions of abdera/axiom for SwitchYard to in line with Camel 2.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <version.net.sourceforge.saxon>9.2.1.5</version.net.sourceforge.saxon>
     <version.org.antlr>3.5</version.org.antlr>
     <version.org.antlr.ST4>4.0.7</version.org.antlr.ST4>
-    <version.org.apache.abdera>1.1.2</version.org.apache.abdera>
+    <version.org.apache.abdera>1.1.3</version.org.apache.abdera>
     <version.org.apache.activemq>5.8.0</version.org.apache.activemq>
     <version.org.apache.ant>1.8.2</version.org.apache.ant>
     <version.org.apache.aries.blueprint>1.0.0</version.org.apache.aries.blueprint>
@@ -180,7 +180,7 @@
     <version.org.apache.qpid>0.18</version.org.apache.qpid>
     <version.org.apache.tika>1.3</version.org.apache.tika>
     <version.org.apache.tomcat>6.0.32</version.org.apache.tomcat>
-    <version.org.apache.ws.commons.axiom>1.2.8</version.org.apache.ws.commons.axiom>
+    <version.org.apache.ws.commons.axiom>1.2.14</version.org.apache.ws.commons.axiom>
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>
     <version.org.apache.xmlgraphics.batik>1.7</version.org.apache.xmlgraphics.batik>


### PR DESCRIPTION
SwitchYard is adding support for camel-atom and camel-rss.     Camel 2.12.2 uses a newer version of axiom than that which is in the integration bom (1.2.14 vs 1.2.8) which causes problems because we're seeing ClassNotFoundExceptions on some of the newer classes added to axiom that exist in 1.2.14 but do not exist in the 1.2.8 version.

Also requesting an update of axiom (1.1.2->1.1.3) to match what is used in Camel 2.12.2 and employed by camel-atom.    
