### PR TITLE
added org.codehaus.btm:btm-tomcat55-lifecycle

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1117,6 +1117,11 @@
         <artifactId>btm</artifactId>
         <version>${version.org.codehaus.btm}</version>
       </dependency>
+      <dependency>
+        <groupId>org.codehaus.btm</groupId>
+        <artifactId>btm-tomcat55-lifecycle</artifactId>
+        <version>${version.org.codehaus.btm}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
As we upgraded the jboss-inegration-platform-bpm to 6.0.0.CR7, there some libraries (https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/commit/936ddde8e3aeb9b48746ed70da81e82f5c964319#diff-c0272a1381174fcc942dcd9a96eb7fd3L498) removed for cleaning up the  kie-parent-with-dependencies/pom.xml .
The droolsjbpm (master) build is failing right now, because one dependency is missing.
This has been added to the ip-bom/bom.xml
