### PR TITLE
Upgrade to jboss-parent:11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>10</version>
+    <version>11</version>
     <relativePath />
   </parent>
 
@@ -89,6 +89,10 @@
 
   <properties>
     <victims.updates>offline</victims.updates>
+
+    <!-- Override Java source/target to be 1.6 -->
+    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
 
     <!--
       CONVENTIONS:


### PR DESCRIPTION
Compiler version is set to 1.6 as 10->11 changes the compiler version. 
