### PR TITLE
Added dependencies required by ModeShape 3.8 (DV 6.1)

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>jboss-integration-platform-bom</artifactId>
-  <version>6.0.0-SNASPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>JBoss Integration Platform BOM</name>
@@ -149,6 +149,16 @@
         <version>${version.com.beust.jcommander}</version>
       </dependency>
       <dependency>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-core</artifactId>
+        <version>${version.com.datastax.cassandra.cassandra-driver-core}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.drewnoakes</groupId>
+        <artifactId>metadata-extractor</artifactId>
+        <version>${version.com.drewnoakes.metadata-extractor}</version>
+      </dependency>
+      <dependency>
         <groupId>com.github.gwtbootstrap</groupId>
         <artifactId>gwt-bootstrap</artifactId>
         <version>${version.com.github.gwtbootstrap}</version>
@@ -240,6 +250,12 @@
         <groupId>com.oracle</groupId>
         <artifactId>ojdbc14</artifactId>
         <version>${version.com.oracle.ojdbc14}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.smartgwt</groupId>
+        <artifactId>smartgwt-skins</artifactId>
+        <version>${version.com.smartgwt.smartgwt-skins}</version>
       </dependency>
 
       <dependency><!-- Keep in sync with groupId javax.xml.bind -->
@@ -1892,6 +1908,11 @@
         <version>${version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec}</version>
       </dependency>
       <dependency>
+        <groupId>org.jboss.spec.javax.resource</groupId>
+        <artifactId>jboss-connector-api_1.6_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.resource.connector-api.1.6}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.spec.javax.security.jacc</groupId>
         <artifactId>jboss-jacc-api_1.4_spec</artifactId>
         <version>${version.org.jboss.spec.javax.security.jacc}</version>
@@ -2253,6 +2274,12 @@
         <groupId>rome</groupId>
         <artifactId>rome</artifactId>
         <version>${version.rome}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>smartgwt</groupId>
+        <artifactId>smartgwt</artifactId>
+        <version>${version.smartgwt}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,8 @@
     <version.commons-vfs>1.0</version.commons-vfs>
     <version.com.allen-sauer.gwt.dnd>3.1.2</version.com.allen-sauer.gwt.dnd>
     <version.com.beust.jcommander>1.5</version.com.beust.jcommander>
+    <version.com.datastax.cassandra.cassandra-driver-core>1.0.0</version.com.datastax.cassandra.cassandra-driver-core>
+    <version.com.drewnoakes.metadata-extractor>2.6.2</version.com.drewnoakes.metadata-extractor>
     <version.com.github.gwtbootstrap>2.2.1.0</version.com.github.gwtbootstrap>
     <version.com.google.code.gin>1.0</version.com.google.code.gin>
     <version.com.google.code.gson>1.7.2</version.com.google.code.gson>
@@ -130,6 +132,7 @@
     <version.com.lowagie.itext>2.1.2</version.com.lowagie.itext>
     <version.com.mchange.c3p0>0.9.2-pre5</version.com.mchange.c3p0>
     <version.com.oracle.ojdbc14>10.2.0.4.0</version.com.oracle.ojdbc14>
+    <version.com.smartgwt.smartgwt-skins>2.4</version.com.smartgwt.smartgwt-skins>
     <version.com.sun.xml.bind.jaxb>2.2.5</version.com.sun.xml.bind.jaxb>
     <version.com.thoughtworks.xstream>1.4.7</version.com.thoughtworks.xstream>
     <version.dom4j>1.6.1</version.dom4j>
@@ -182,7 +185,7 @@
     <version.org.apache.maven.wagon>1.0</version.org.apache.maven.wagon>
     <version.org.apache.maven.wagon.http>2.0</version.org.apache.maven.wagon.http>
     <version.org.apache.mina>2.0.4</version.org.apache.mina>
-    <version.org.apache.poi>3.10</version.org.apache.poi>
+    <version.org.apache.poi>3.10-FINAL</version.org.apache.poi>
     <version.org.apache.qpid>0.18</version.org.apache.qpid>
     <version.org.apache.tika>1.3</version.org.apache.tika>
     <version.org.apache.tomcat>6.0.32</version.org.apache.tomcat>
@@ -239,6 +242,7 @@
     <version.org.jboss.spec.javax.ejb.3.1>1.0.2.Final</version.org.jboss.spec.javax.ejb.3.1>
     <version.org.jboss.spec.javax.el.2.2>1.0.2.Final</version.org.jboss.spec.javax.el.2.2>
     <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
+    <version.org.jboss.spec.javax.resource.connector-api.1.6>1.0.1.Final</version.org.jboss.spec.javax.resource.connector-api.1.6>
     <version.org.jboss.spec.javax.security.jacc>1.0.0.Final</version.org.jboss.spec.javax.security.jacc>
     <version.org.jboss.spec.javax.servlet.3.0>1.0.2.Final</version.org.jboss.spec.javax.servlet.3.0>
     <version.org.jboss.spec.javax.servlet.jsp.2.2>1.0.1.Final</version.org.jboss.spec.javax.servlet.jsp.2.2>
@@ -281,6 +285,7 @@
     <version.postgresql>8.4-702.jdbc4</version.postgresql>
     <version.rhino.js>1.7R2</version.rhino.js>
     <version.rome>1.0</version.rome>
+    <version.smartgwt>2.4</version.smartgwt>
     <version.tranql.connector>1.2</version.tranql.connector>
     <version.transql.connector-sqlserver2005>1.3</version.transql.connector-sqlserver2005>
     <version.wsdl4j>1.6.2</version.wsdl4j>


### PR DESCRIPTION
The following artifacts were added:
- `com.datastax.cassandra:cassandra-driver-core`
- `com.drewnoakes:metadata-extractor`
- `com.smartgwt:smartgwt-skins`
- `smartgwt:smartgwt`
- `org.jboss.spec.javax.resource:jboss-connector-api_1.6_spec`

The PR also contains a temporary fix (via a property) for the problem described on the mailing list regarding the enforcer plugin and managed dependencies from profiles. The temporary fix can be removed (if desired) later on, when the plugin is fixed.
