### PR TITLE
Roaster library added

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1833,6 +1833,18 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss.forge.roaster</groupId>
+        <artifactId>roaster-api</artifactId>
+        <version>${version.org.jboss.forge.roaster}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.forge.roaster</groupId>
+        <artifactId>roaster-jdt</artifactId>
+        <version>${version.org.jboss.forge.roaster}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.seam.security</groupId>
         <artifactId>seam-security</artifactId>
         <version>${version.org.jboss.seam.security}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,7 @@
     <version.org.jboss.marshalling>1.4.5.Final</version.org.jboss.marshalling>
     <version.org.jboss.netty>3.2.6.Final</version.org.jboss.netty>
     <version.org.jboss.resteasy>2.3.7.Final</version.org.jboss.resteasy>
+    <version.org.jboss.forge.roaster>2.4.0.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.seam.security>3.2.0.Final</version.org.jboss.seam.security>
     <version.org.jboss.seam>3.1.0.Final</version.org.jboss.seam>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-3</version.org.jboss.shrinkwrap.descriptors>


### PR DESCRIPTION
Roaster is a library from Jboss Forge project used to manage .java files, and needed in the context of kie-wb projects.
