### PR TITLE
Upgrade Infinispan from 5.2.9.Final to 5.2.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
     <version.org.hibernate.javax.persistence>1.0.1.Final</version.org.hibernate.javax.persistence>
     <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
     <version.org.hornetq>2.3.18.Final</version.org.hornetq>
-    <version.org.infinispan>5.2.9.Final</version.org.infinispan>
+    <version.org.infinispan>5.2.10.Final</version.org.infinispan>
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>


### PR DESCRIPTION
Reason:  the new version fixes a small problem in the manifest.mf that prevents it from deploying properly into karaf/fuse.
