### PR TITLE
removed <execution> enforce-victims-rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,21 +358,6 @@
             </configuration>
           </execution>
 
-          <execution>
-            <id>enforce-victims-rule</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <rule implementation="com.redhat.victims.VictimsRule">
-                  <metadata>warning</metadata>
-                  <fingerprint>fatal</fingerprint>
-                  <updates>${victims.updates}</updates>
-                </rule>
-              </rules>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
The enforce-victims-rule activated in maven-enforcer-plugin prevents from building projects when a dependency a vulnerability is found. 
It would be good to have this enforcer rule only activated when releasing (a full profile -Dfull) and not activated when doing a daily build or local builds, since due to the weekly actualization of the victims database a lot of time builds that worked today don't work any more after actualization.  The developer could stuck in their development since they have now to solve first this vulnerability and can't continue with their features. 
