### PR TITLE
downgraded jboss-as to 7.2.0.Final

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -984,6 +984,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.apache.neethi</groupId>
+        <artifactId>neethi</artifactId>
+        <version>${version.org.apache.neethi}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>
         <version>${version.org.apache.mina}</version>
@@ -1052,6 +1058,11 @@
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-dom</artifactId>
         <version>${version.org.apache.ws.commons.axiom}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ws.xmlschema</groupId>
+        <artifactId>xmlschema-core</artifactId>
+        <version>${version.org.apache.xmlschema-core}</version>
       </dependency>
 
       <dependency>
@@ -2317,6 +2328,11 @@
         <groupId>org.subethamail</groupId>
         <artifactId>subethasmtp-wiser</artifactId>
         <version>${version.org.subethamail}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.subethamail</groupId>
+        <artifactId>subethasmtp</artifactId>
+        <version>${version.org.subethamail.subethasmtp}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
     <version.org.apache.maven.wagon>1.0</version.org.apache.maven.wagon>
     <version.org.apache.maven.wagon.http>2.0</version.org.apache.maven.wagon.http>
     <version.org.apache.mina>2.0.4</version.org.apache.mina>
+    <version.org.apache.neethi>3.0.2</version.org.apache.neethi>
     <version.org.apache.poi>3.10-FINAL</version.org.apache.poi>
     <version.org.apache.qpid>0.18</version.org.apache.qpid>
     <version.org.apache.tika>1.3</version.org.apache.tika>
@@ -196,6 +197,7 @@
     <version.org.apache.ws.commons.axiom>1.2.8</version.org.apache.ws.commons.axiom>
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>
+    <version.org.apache.xmlschema-core>2.0.3</version.org.apache.xmlschema-core>
     <version.org.apache.xmlgraphics.batik>1.7</version.org.apache.xmlgraphics.batik>
     <version.org.beanshell>1.3.0</version.org.beanshell>
     <version.org.clojure>1.3.0-alpha5</version.org.clojure>
@@ -288,6 +290,7 @@
     <version.org.springframework>3.0.7.RELEASE</version.org.springframework>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
     <version.org.subethamail>1.2</version.org.subethamail>
+    <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
     <version.org.timepedia.chronoscope>2.0_jboss</version.org.timepedia.chronoscope>
     <version.org.timepedia.exporter>2.0.10</version.org.timepedia.exporter>
     <version.org.xmappr>0.9.3</version.org.xmappr>


### PR DESCRIPTION
jboss-as-arquillian-container-managed
jboss-as-naming
jboss-as-server

used by droolsjbpm projects are not present in Nexus with version 7.4.0.Final.
It only exist 7.2.0.Final version.

Our droolsjbpm/jbpm on master is failing because of unsatisfied dependencies.
