### PR TITLE
Using a different version for arquillian jboss containers

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1461,7 +1461,7 @@
       <dependency>
         <groupId>org.jboss.as</groupId>
         <artifactId>jboss-as-arquillian-container-managed</artifactId>
-        <version>${version.org.jboss.as}</version>
+        <version>${version.org.jboss.as.arquillian}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,7 @@
     <version.org.jboss.arquillian>1.0.3.Final</version.org.jboss.arquillian>
     <version.org.jboss.arquillian.container.glassfish>1.0.0.CR3</version.org.jboss.arquillian.container.glassfish>
     <version.org.jboss.arquillian.container.weld>1.0.0.CR5</version.org.jboss.arquillian.container.weld>
+    <version.org.jboss.as.arquillian>7.2.0.Final</version.org.jboss.as.arquillian>
     <version.org.jboss.as>7.4.0.Final</version.org.jboss.as>
     <version.org.jboss.errai>2.4.4.Final</version.org.jboss.errai>
     <version.org.jboss.ironjacamar>1.0.26.Final</version.org.jboss.ironjacamar>


### PR DESCRIPTION
The `<version.org.jboss.as>` property has been upgraded to 7.4.0.Final, but the `org.jboss.as:jboss-as-arquillian-container-managed` dependency uses the same property. 

The problem is that there is no `org.jboss.as:jboss-as-arquillian-container-managed:7.4.0.Final` artifact (for 7.2.0.Final+, only internal *-redhat-x `org.jboss.as:jboss-as-arquillian-container-managed` artifacts are available)

This pull requests introduces a new property (`<version.org.jboss.as.arquillian>`) for use in the management of the `org.jboss.as:jboss-as-arquillian-container-managed` dependency. 

(Also, the `org.jboss.as:jboss-as-arquillian-container-managed:7.2.0.Final` has worked fine with all 7.2.0.Final+ containers (tested last with 7.4.0.Final-redhat-17, even.. )). 
