### PR TITLE
Roaster library upgrade to 2.7.1.Final 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
     <version.org.jboss.marshalling>1.4.5.Final</version.org.jboss.marshalling>
     <version.org.jboss.netty>3.2.6.Final</version.org.jboss.netty>
     <version.org.jboss.resteasy>2.3.7.Final</version.org.jboss.resteasy>
-    <version.org.jboss.forge.roaster>2.4.0.Final</version.org.jboss.forge.roaster>
+    <version.org.jboss.forge.roaster>2.7.1.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.seam.security>3.2.0.Final</version.org.jboss.seam.security>
     <version.org.jboss.seam>3.1.0.Final</version.org.jboss.seam>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-3</version.org.jboss.shrinkwrap.descriptors>


### PR DESCRIPTION
Roaster library upgrade to 2.7.1.Final required for "JBPM-4404 - Integration with uberfire navigation, and unification with the kie-wb editors"
