### PR TITLE
Add illegal-transitive-dependency-check enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
 
   <properties>
     <victims.updates>weekly</victims.updates>
+    <illegaltransitivereportonly>false</illegaltransitivereportonly>
 
     <!-- Override Java source/target to be 1.6 -->
     <maven.compiler.target>1.6</maven.compiler.target>
@@ -323,6 +324,11 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <dependencies>
           <dependency>
+            <groupId>de.is24.maven.enforcer.rules</groupId>
+            <artifactId>illegal-transitive-dependency-check</artifactId>
+            <version>1.5</version>
+          </dependency>
+          <dependency>
             <groupId>com.redhat.victims</groupId>
             <artifactId>enforce-victims-rule</artifactId>
             <version>1.3.4</version>
@@ -362,8 +368,27 @@
             </configuration>
           </execution>
 
+          <execution>
+            <id>enforce-direct-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <illegalTransitiveDependencyCheck implementation="de.is24.maven.enforcer.rules.IllegalTransitiveDependencyCheck">
+                  <reportOnly>${illegaltransitivereportonly}</reportOnly>
+                  <regexIgnoredClasses>
+                      <regexIgnoredClass>javax\..+</regexIgnoredClass>
+                      <regexIgnoredClass>org\.w3c\.dom\..+</regexIgnoredClass>
+                      <regexIgnoredClass>org\.xml\.sax\..+</regexIgnoredClass>
+                  </regexIgnoredClasses>
+                </illegalTransitiveDependencyCheck>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This adds https://github.com/ImmobilienScout24/illegal-transitive-dependency-check which will check that code uses dependencies that have been explicitly added rather than using transitive dependencies.

It has been defaulted to failing the build if it finds a problem. If `-Dillegaltransitivereportonly=true` is set then it will create report files (e.g. itd-xxxxx-<version>.txt) in the target directory for each module.
