### PR TITLE
Updated org.apache.httpcomponents:httpclient to 4.3.5.

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -904,12 +904,12 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>${version.org.apache.httpcomponents}</version>
+        <version>${version.org.apache.httpcomponents.httpclient}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>${version.org.apache.httpcomponents}</version>
+        <version>${version.org.apache.httpcomponents.httpcore}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,8 @@
     <version.org.apache.deltaspike.core>1.0.0</version.org.apache.deltaspike.core>
     <version.org.apache.ftpserver>1.0.6</version.org.apache.ftpserver>
     <version.org.apache.helix>0.6.2-incubating</version.org.apache.helix>
-    <version.org.apache.httpcomponents>4.2.1</version.org.apache.httpcomponents>
+    <version.org.apache.httpcomponents.httpclient>4.3.5</version.org.apache.httpcomponents.httpclient>
+    <version.org.apache.httpcomponents.httpcore>4.3.2</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.karaf>2.3.3</version.org.apache.karaf>
     <version.org.apache.lucene>3.6.2</version.org.apache.lucene>
     <version.org.apache.lucene.regex>3.0.3</version.org.apache.lucene.regex>


### PR DESCRIPTION
This was required because of the following CVE: http://mail-archives.apache.org/mod_mbox/www-announce/201408.mbox/CVE-2014-3577. For additional information you can also check out https://bugzilla.redhat.com/show_bug.cgi?id=1129074.

Since there is no corresponding `httpcore` with this version, the 2 artifacts had to be split up, considering that:

```
 org.apache.httpcomponents:httpclient:jar:4.3.5:compile
 +- org.apache.httpcomponents:httpcore:jar:4.3.2:compile
```
