### PR TITLE
Remove orphan org.jboss.netty dependency

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1949,12 +1949,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.jboss.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>${version.org.jboss.netty}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.jboss</groupId>
         <artifactId>staxmapper</artifactId>
         <version>${version.org.jboss.staxmapper}</version>


### PR DESCRIPTION
There is no version.org.jboss.netty defined in jboss-integration-parent.
And org.jboss.netty is old and it seems that no project require org.jboss.netty any more.
Project should use io.netty instead.
