### PR TITLE
Ignore transitive dependency check for com.sun.net.httpserver.* as this ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,7 @@
                 <illegalTransitiveDependencyCheck implementation="de.is24.maven.enforcer.rules.IllegalTransitiveDependencyCheck">
                   <reportOnly>${illegaltransitivereportonly}</reportOnly>
                   <regexIgnoredClasses>
+                      <regexIgnoredClass>com\.sun\.net\.httpserver\..+</regexIgnoredClass>
                       <regexIgnoredClass>javax\..+</regexIgnoredClass>
                       <regexIgnoredClass>org\.w3c\.dom\..+</regexIgnoredClass>
                       <regexIgnoredClass>org\.xml\.sax\..+</regexIgnoredClass>


### PR DESCRIPTION
...is provided by the jdk
