### PR TITLE
BZ 1128609 Make the version match EAP versions, also commented on some k...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <version.javax.enterprise>1.0-SP4</version.javax.enterprise>
     <version.javax.inject>1</version.javax.inject>
     <version.javax.jcr>2.0</version.javax.jcr>
-    <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.1</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
+    <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
     <version.javax.mail>1.4.5</version.javax.mail>
     <version.javax.validation>1.0.0.GA</version.javax.validation>
     <version.jaxen>1.1.3</version.jaxen>
@@ -193,7 +193,7 @@
     <version.org.apache.ws.commons.axiom>1.2.14</version.org.apache.ws.commons.axiom>
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.apache.xmlbeans>2.3.0</version.org.apache.xmlbeans>
-    <version.org.apache.ws.xmlschema>2.0.3</version.org.apache.ws.xmlschema>
+    <version.org.apache.ws.xmlschema>2.0.2</version.org.apache.ws.xmlschema>
     <version.org.apache.xmlgraphics.batik>1.7</version.org.apache.xmlgraphics.batik>
     <version.org.beanshell>1.3.0</version.org.beanshell>
     <version.org.clojure>1.3.0-alpha5</version.org.clojure>
@@ -215,12 +215,14 @@
     <version.org.eclipse.jgit>2.1.0.201209190230-r</version.org.eclipse.jgit>
     <version.org.freemarker>2.3.19</version.org.freemarker>
     <version.org.glassfish>3.1.2</version.org.glassfish>
-    <version.org.hibernate>4.2.12.Final</version.org.hibernate>
+    <!--EAP 6.3 use hibernate 4.2.14.SP1-redhat-1, however no equiverlant in community release, so  the closest version wins-->
+    <version.org.hibernate>4.2.15.Final</version.org.hibernate>
     <version.org.hibernate.search>4.3.0.Final</version.org.hibernate.search>
     <version.org.hibernate.validator>4.3.1.Final</version.org.hibernate.validator>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
-    <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
-    <version.org.hornetq>2.3.18.Final</version.org.hornetq>
+    <version.org.hibernate.commons.annotations>4.0.1.Final</version.org.hibernate.commons.annotations>
+    <!--EAP 6.3 use hornetq 2.3.20.Final-redhat-1, however no equiverlant in community release, so  the closest version wins-->
+    <version.org.hornetq>2.3.19.Final</version.org.hornetq>
     <version.org.infinispan>5.2.10.Final</version.org.infinispan>
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>1.3</version.org.hamcrest>
@@ -239,6 +241,7 @@
     <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.logging.jboss-logging-processor>1.1.0.Final</version.org.jboss.logging.jboss-logging-processor>
     <version.org.jboss.marshalling.jboss-marshalling>1.4.6.Final</version.org.jboss.marshalling.jboss-marshalling>
+    <!--EAP 6.3 use resteasy 2.3.8.Final-redhat-3, however no equiverlant in community release, so  the closest version wins-->
     <version.org.jboss.resteasy>2.3.7.Final</version.org.jboss.resteasy>
     <version.org.jboss.forge.roaster>2.7.1.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.seam.security>3.2.0.Final</version.org.jboss.seam.security>
@@ -253,15 +256,15 @@
     <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>1.0.3.Final</version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>
     <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec>
     <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec>1.0.1.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec>
-    <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.0.5.Final</version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
+    <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.0.6.Final</version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_1.1_spec>
     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
     <version.org.jboss.solder>3.2.1.Final</version.org.jboss.solder>
     <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
-    <version.org.jboss.weld.weld>1.1.21.Final</version.org.jboss.weld.weld>
+    <version.org.jboss.weld.weld>1.1.23.Final</version.org.jboss.weld.weld>
     <version.org.jboss.weld.weld-api>1.1.Final</version.org.jboss.weld.weld-api>
-    <version.org.jbpm.jbpm5.jbpmmigration>0.12</version.org.jbpm.jbpm5.jbpmmigration>
+    <version.org.jbpm.jbpm5.jbpmmigration>0.13</version.org.jbpm.jbpm5.jbpmmigration>
     <!-- EAP uses jdom 1.1.2 but that breaks jenkins builds with the error "Could not find artifact maven-plugins:maven-cobertura-plugin:plugin:1.3" -->
     <version.org.jdom>1.1.3</version.org.jdom>
     <version.org.jfree.jfreechart>1.0.19</version.org.jfree.jfreechart>
@@ -298,7 +301,7 @@
     <version.smartgwt>2.4</version.smartgwt>
     <version.tranql.connector>1.2</version.tranql.connector>
     <version.transql.connector-sqlserver2005>1.3</version.transql.connector-sqlserver2005>
-    <version.wsdl4j>1.6.2</version.wsdl4j>
+    <version.wsdl4j>1.6.3</version.wsdl4j>
     <version.org.apache.xalan>2.7.1</version.org.apache.xalan>
     <version.org.apache.xerces>2.9.1</version.org.apache.xerces>
     <version.xml-apis>1.3.04</version.xml-apis>


### PR DESCRIPTION
This is for aligning to EAP 6.3's versions.
See https://bugzilla.redhat.com/show_bug.cgi?id=1128609

This PR has been acked and is the rebased version of PR #106 (https://github.com/jboss-integration/jboss-integration-platform-bom/pull/106#issuecomment-55739488 )
