### PR TITLE
Upgrade hibernate common annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
     <version.org.hibernate.search>4.3.0.Final</version.org.hibernate.search>
     <version.org.hibernate.validator>4.3.1.Final</version.org.hibernate.validator>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
-    <version.org.hibernate.commons.annotations>4.0.1.Final</version.org.hibernate.commons.annotations>
+    <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
     <!--EAP 6.3 use hornetq 2.3.20.Final-redhat-1, however no equiverlant in community release, so  the closest version wins-->
     <version.org.hornetq>2.3.19.Final</version.org.hornetq>
     <version.org.infinispan>5.2.10.Final</version.org.infinispan>


### PR DESCRIPTION
SwitchYard needs the OSGi metadata which isn't included in 4.0.1.Final.
