### PR TITLE
Downgrade axiom due to install issue in Karaf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <version.org.apache.sshd>0.12.0</version.org.apache.sshd>
     <version.org.apache.tika>1.3</version.org.apache.tika>
     <version.org.apache.tomcat>6.0.32</version.org.apache.tomcat>
-    <version.org.apache.ws.commons.axiom>1.2.14</version.org.apache.ws.commons.axiom>
+    <version.org.apache.ws.commons.axiom>1.2.12</version.org.apache.ws.commons.axiom>
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.apache.velocity.velocity-tools>2.0</version.org.apache.velocity.velocity-tools>
     <version.org.apache.xmlbeans>2.6.0</version.org.apache.xmlbeans>


### PR DESCRIPTION
Version 1.2.14 of axiom causes the following error when installing in Karaf:
"Error executing command: Manifest not present in the first entry of the zip mvn:org.apache.ws.commons.axiom/axiom-impl/1.2.14"

Same issue reported against camel (https://issues.apache.org/jira/browse/CAMEL-6059), so suggesting the same approach - downgrade to 1.2.12.
