### PR TITLE
Add enforcer rule that bans uberjars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,25 @@
               </rules>
             </configuration>
           </execution>
+          
+          <execution>
+            <id>ban-uberjars</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.apache.cxf:cxf-bundle-jaxrs</exclude>
+                    <exclude>org.jboss.weld.se:weld-se</exclude><!-- Use weld-se-core instead -->
+                    <exclude>org.jboss.weld.servlet:weld-servlet</exclude><!-- Use weld-servlet-core instead -->
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 


### PR DESCRIPTION
These uberjars are bundling a lots of other classes from different artifacts directly inside them and that disrupts the maven dependency resolution. The only way to completely prevent their usage is to ban them.

We have had a lots of problems with them in Drools/jBPM and as discussed with @ge0ffrey banning them is the only way how to make sure they won't creep up again in to the dependency tree.
