### PR TITLE
Align to EAP 6.3.1 GA

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -309,15 +309,15 @@
         <version>${version.com.smartgwt.smartgwt-skins}</version>
       </dependency>
 
-      <dependency><!-- Keep in sync with groupId javax.xml.bind -->
+      <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
-        <version>${version.com.sun.xml.bind.jaxb}</version>
+        <version>${version.com.sum.xml.bind}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-xjc</artifactId>
-        <version>${version.com.sun.xml.bind.jaxb}</version>
+        <version>${version.com.sum.xml.bind}</version>
       </dependency>
 
       <dependency>
@@ -380,10 +380,10 @@
         <artifactId>validation-api</artifactId>
         <version>${version.javax.validation}</version>
       </dependency>
-      <dependency><!-- Keep in sync with groupId com.sun.xml.bind -->
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>${version.com.sun.xml.bind.jaxb}</version>
+      <dependency>
+        <groupId>org.jboss.spec.javax.xml.bind</groupId>
+        <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+        <version>${org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.com.oracle.ojdbc14>10.2.0.4.0</version.com.oracle.ojdbc14>
     <version.com.smartgwt.smartgwt-skins>2.4</version.com.smartgwt.smartgwt-skins>
-    <version.com.sun.xml.bind.jaxb>2.2.5</version.com.sun.xml.bind.jaxb>
+    <version.com.sun.xml.bind>2.2.5</version.com.sun.xml.bind>
     <version.com.thoughtworks.xstream>1.4.7</version.com.thoughtworks.xstream>
     <version.dom4j>1.6.1</version.dom4j>
     <version.io.netty>3.6.9.Final</version.io.netty>
@@ -275,6 +275,7 @@
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_1.1_spec>
     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
+    <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
     <version.org.jboss.solder>3.2.1.Final</version.org.jboss.solder>
     <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
     <version.org.jboss.weld.weld>1.1.23.Final</version.org.jboss.weld.weld>


### PR DESCRIPTION
Align to EAP 6.3.1 GA, changes including: 
1)property version.com.sun.xml.bind.jaxb->version.com.sun.xml.bind 
2)httpclient 4.3.5->4.2.6, httpcore 4.3.2->4.2.5 
3)javax.xml.bind:jaxb-api->org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.2_spec
