### PR TITLE
Remove common-httpclient-3.1 for CVE-2012-6153

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -110,11 +110,6 @@
         <version>${version.commons-fileupload}</version>
       </dependency>
       <dependency>
-        <groupId>commons-httpclient</groupId>
-        <artifactId>commons-httpclient</artifactId>
-        <version>${version.commons-httpclient}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-jxpath</groupId>
         <artifactId>commons-jxpath</artifactId>
         <version>${version.commons-jxpath}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
     <version.commons-dbcp>1.4</version.commons-dbcp>
     <version.commons-digester>1.8</version.commons-digester>
     <version.commons-fileupload>1.3.1</version.commons-fileupload>
-    <version.commons-httpclient>3.1</version.commons-httpclient>
     <version.commons-jxpath>1.3</version.commons-jxpath>
     <version.commons-lang>2.6</version.commons-lang>
     <version.commons-logging>1.1.1</version.commons-logging>


### PR DESCRIPTION
Hi, 
There is CVE reported in https://bugzilla.redhat.com/show_bug.cgi?id=1129916#c9
And noticed that it impacts brms/bpmsuite. We need to get rid of common-httpclient.
it should be updated to httpcomponets-httpclient 4.5.3 which has already been defined in jboss-integraiton-platform-bom.

This might also need droolsjbpm projects to remove the dependency on common-httpclient also since it is present in brms/bpmsuite 6.1:
find . -name "commons-httpclient*"
./jboss-eap-6.3/standalone/deployments/kie-execution-server.war/WEB-INF/lib/commons-httpclient-3.1.jar
./jboss-eap-6.3/modules/system/layers/bpms/org/apache/commons/httpclient/main/commons-httpclient-3.1.jar
./jboss-bpms-6.1.0.redhat-3-deployable-generic/jboss-bpms-engine/jboss-bpms-engine/lib/commons-httpclient-3.1.jar
./jboss-bpms-6.1.0.redhat-3-deployable-generic/jboss-bpms-manager/jboss-bpms-manager/standalone/deployments/kie-execution-server.war/WEB-INF/lib/commons-httpclient-3.1.jar
./jboss-bpms-6.1.0.redhat-3-deployable-generic/jboss-bpms-manager/jboss-bpms-manager/business-central.war/WEB-INF/lib/commons-httpclient-3.1.jar
