### PR TITLE
SWITCHYARD-2425 update to Karaf 2.4 and Camel 2.14

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -690,6 +690,12 @@
           <groupId>org.apache.camel</groupId>
           <artifactId>camel-cxf</artifactId>
           <version>${version.org.apache.camel}</version>
+          <exclusions>
+              <exclusion>
+                  <groupId>org.apache.cxf</groupId>
+                  <artifactId>cxf-core</artifactId>
+              </exclusion>
+          </exclusions>
       </dependency>
       <dependency>
           <groupId>org.apache.camel</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
     <version.org.apache.activemq>5.8.0</version.org.apache.activemq>
     <version.org.apache.ant>1.8.2</version.org.apache.ant>
     <version.org.apache.aries.blueprint>1.0.0</version.org.apache.aries.blueprint>
-    <version.org.apache.camel>2.12.2</version.org.apache.camel>
+    <version.org.apache.camel>2.14.0</version.org.apache.camel>
     <version.org.apache.chemistry.opencmis>0.11.0</version.org.apache.chemistry.opencmis>
     <version.org.apache.commons.compress>1.4.1</version.org.apache.commons.compress>
     <version.org.apache.commons.exec>1.0.1</version.org.apache.commons.exec>
@@ -186,7 +186,7 @@
     <version.org.apache.helix>0.6.2-incubating</version.org.apache.helix>
     <version.org.apache.httpcomponents.httpclient>4.3.5</version.org.apache.httpcomponents.httpclient>
     <version.org.apache.httpcomponents.httpcore>4.3.2</version.org.apache.httpcomponents.httpcore>
-    <version.org.apache.karaf>2.3.3</version.org.apache.karaf>
+    <version.org.apache.karaf>2.4.0</version.org.apache.karaf>
     <version.org.apache.lucene>3.6.2</version.org.apache.lucene>
     <version.org.apache.lucene.regex>3.0.3</version.org.apache.lucene.regex>
     <version.org.apache.maven>3.0.5</version.org.apache.maven>


### PR DESCRIPTION
Align Karaf and Camel versions with Fuse 6.2.  These changes are require for the next D/ER build of FSW.

https://issues.jboss.org/browse/SWITCHYARD-2425
