### PR TITLE
added versions and dependencies for satisfying requireUpperBoundDeps

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -48,6 +48,11 @@
       </dependency>
 
       <!-- Keep in sync with groupId org.slf4j -->
+      <dependency><!-- drools-wb -->
+        <groupId>ch.qos.cal10n</groupId>
+        <artifactId>cal10n-api</artifactId>
+        <version>${version.ch.qos.cal10n.cal10n-api}</version>
+      </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
@@ -1445,6 +1450,26 @@
         <version>${version.org.eclipse.emf.ecore.xmi}</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-continuation</artifactId>
+        <version>${version.org.eclipse.jetty.jetty-security}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
+        <version>${version.org.eclipse.jetty.jetty-security}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-io</artifactId>
+        <version>${version.org.eclipse.jetty.jetty-security}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${version.org.eclipse.jetty.jetty-security}</version>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.jdt.core.compiler</groupId>
         <artifactId>ecj</artifactId>
         <version>${version.org.eclipse.jdt.core.compiler}</version>
@@ -1454,6 +1479,7 @@
         <artifactId>org.eclipse.jgit</artifactId>
         <version>${version.org.eclipse.jgit}</version>
       </dependency>
+
 
       <dependency>
         <groupId>org.freemarker</groupId>
@@ -1724,6 +1750,16 @@
         <groupId>org.jboss.ironjacamar</groupId>
         <artifactId>ironjacamar-jdbc</artifactId>
         <version>${version.org.jboss.ironjacamar}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.osgi.metadata</groupId>
+        <artifactId>jbosgi-metadata</artifactId>
+        <version>${version.org.jboss.osgi.metadata.jbosgi-metadata}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.osgi.vfs</groupId>
+        <artifactId>jbosgi-vfs30</artifactId>
+        <version>${version.org.jboss.osgi.vfs}</version>
       </dependency>
 
       <dependency>
@@ -2022,6 +2058,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss.remoting3</groupId>
+        <artifactId>jboss-remoting</artifactId>
+        <version>${version.org.jboss.remoting3.jboss-remoting}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.forge.roaster</groupId>
         <artifactId>roaster-api</artifactId>
         <version>${version.org.jboss.forge.roaster}</version>
@@ -2104,6 +2146,11 @@
         <version>${version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec}</version>
       </dependency>
       <dependency>
+        <groupId>org.jboss.spec.javax.interceptor</groupId>
+        <artifactId>jboss-interceptors-api_1.1_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.interceptor-jboss-interceptors-api}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.spec.javax.jms</groupId>
         <artifactId>jboss-jms-api_1.1_spec</artifactId>
         <version>${version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec}</version>
@@ -2178,6 +2225,11 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-spi</artifactId>
         <version>${version.org.jboss.weld.weld-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.xnio</groupId>
+        <artifactId>xnio-api</artifactId>
+        <version>${version.org.jboss.xnio}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.xnio</groupId>
@@ -2299,6 +2351,12 @@
         <groupId>org.quartz-scheduler</groupId>
         <artifactId>quartz</artifactId>
         <version>${version.org.quartz-scheduler}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>${version.org.objenesis.objenesis}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
     <version.aopalliance>1.0</version.aopalliance>
     <version.asm>3.3.1</version.asm>
     <version.ca.uhn.hapi>2.1</version.ca.uhn.hapi>
+    <version.ch.qos.cal10n.cal10n-api>0.7.7</version.ch.qos.cal10n.cal10n-api>
     <version.ch.qos.logback>1.0.9</version.ch.qos.logback>
     <version.commons-cli>1.2</version.commons-cli>
     <version.commons-codec>1.4</version.commons-codec>
@@ -223,6 +224,7 @@
     <version.org.eclipse.emf>2.6.0.v20100614-1136</version.org.eclipse.emf>
     <version.org.eclipse.emf.ecore.xmi>2.5.0.v20100521-1846</version.org.eclipse.emf.ecore.xmi>
     <version.org.eclipse.jdt.core.compiler>4.3.1</version.org.eclipse.jdt.core.compiler>
+    <version.org.eclipse.jetty.jetty-security>8.1.14.v20131031</version.org.eclipse.jetty.jetty-security>
     <version.org.eclipse.jgit>3.3.2.201404171909-r</version.org.eclipse.jgit>
     <version.org.freemarker>2.3.19</version.org.freemarker>
     <version.org.glassfish>3.1.2</version.org.glassfish>
@@ -254,10 +256,13 @@
     <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.logging.jboss-logging-processor>1.1.0.Final</version.org.jboss.logging.jboss-logging-processor>
     <version.org.jboss.marshalling>1.4.6.Final</version.org.jboss.marshalling>
+    <version.org.jboss.osgi.metadata.jbosgi-metadata>2.2.0.Final</version.org.jboss.osgi.metadata.jbosgi-metadata>
+    <version.org.jboss.osgi.vfs>1.2.1.Final</version.org.jboss.osgi.vfs>
     <!--EAP 6.3 use resteasy 2.3.8.Final-redhat-3, however no equiverlant in community release, so  the closest version wins-->
     <version.org.jboss.resteasy>2.3.7.Final</version.org.jboss.resteasy>
     <version.org.jboss.forge.roaster>2.7.1.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.remote-naming>1.0.8.Final</version.org.jboss.remote-naming>
+    <version.org.jboss.remoting3.jboss-remoting>3.2.8.GA</version.org.jboss.remoting3.jboss-remoting>
     <version.org.jboss.seam.security>3.2.0.Final</version.org.jboss.seam.security>
     <version.org.jboss.seam>3.1.0.Final</version.org.jboss.seam>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-3</version.org.jboss.shrinkwrap.descriptors>
@@ -265,6 +270,7 @@
     <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.1_spec>
     <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>
     <version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>
+    <version.org.jboss.spec.javax.interceptor-jboss-interceptors-api>1.0.1.Final</version.org.jboss.spec.javax.interceptor-jboss-interceptors-api>
     <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
     <version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec>1.0.1.Final</version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec>
     <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>1.0.3.Final</version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>
@@ -297,6 +303,7 @@
     <version.org.mockito>1.9.5</version.org.mockito>
     <version.org.mongodb.mongo-java-driver>2.7.3</version.org.mongodb.mongo-java-driver>
     <version.org.mvel>2.2.2.Final</version.org.mvel>
+    <version.org.objenesis.objenesis>2.1</version.org.objenesis.objenesis>
     <version.org.ocpsoft.prettytime>3.0.2.Final</version.org.ocpsoft.prettytime>
     <version.org.osgi>4.3.1</version.org.osgi>
     <version.org.ops4j.pax.exam>3.5.0</version.org.ops4j.pax.exam>
@@ -332,6 +339,8 @@
     <version.xmlpull>1.1.3.1</version.xmlpull>
     <version.xmlunit>1.3</version.xmlunit>
     <version.xpp3>1.1.4c</version.xpp3>
+
+
   </properties>
 
   <build>


### PR DESCRIPTION
to ensure requireUpperBoundDeps enabled doesn't break the build of jbpm, droolsjbpm-integration, drools-wb and kie-wb-distributions this versions and dependencies should be added to jboss-ip-bom 
