### PR TITLE
Update Weld to v. 1.1.25.Final to align with EAP 6.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
     <version.org.jboss.solder>3.2.1.Final</version.org.jboss.solder>
     <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
-    <version.org.jboss.weld.weld>1.1.23.Final</version.org.jboss.weld.weld>
+    <version.org.jboss.weld.weld>1.1.25.Final</version.org.jboss.weld.weld>
     <version.org.jboss.weld.weld-api>1.1.Final</version.org.jboss.weld.weld-api>
     <version.org.jboss.xnio>3.0.9.GA</version.org.jboss.xnio>
     <version.org.jbpm.jbpm5.jbpmmigration>0.13</version.org.jbpm.jbpm5.jbpmmigration>


### PR DESCRIPTION
According to https://maven.repository.redhat.com/techpreview/all/org/jboss/bom/eap6-supported-artifacts/6.3.2.GA/eap6-supported-artifacts-6.3.2.GA.pom the Weld version in EAP 6.3.2.GA was updated to 1.1.25.Final.
