### PR TITLE
Adding webservices (based on jbossws/cxf) dependencies, based on EAP 6.4

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -912,10 +912,99 @@
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-bindings-soap</artifactId>
         <version>${version.org.apache.cxf}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>saaj-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-activation_1.1_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-javamail_1.4_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-annotation_1.0_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-frontend-jaxws</artifactId>
+        <version>${version.org.apache.cxf}</version>
+         <exclusions>
+          <exclusion>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>saaj-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-activation_1.1_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-javamail_1.4_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jaxws_2.1_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>asm</groupId>
+            <artifactId>asm</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+          </exclusion>
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-asm</artifactId>
+          </exclusion>   
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-beans</artifactId>
+          </exclusion> 
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-context</artifactId>
+          </exclusion> 
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-core</artifactId>
+          </exclusion>
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-expression</artifactId>
+          </exclusion>   
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+          </exclusion>
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-jms</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-core</artifactId>
         <version>${version.org.apache.cxf}</version>
       </dependency>
       <dependency>
@@ -952,13 +1041,62 @@
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-frontend-simple</artifactId>
+        <version>${version.org.apache.cxf}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-transports-http</artifactId>
         <version>${version.org.apache.cxf}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-javamail_1.4_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+          </exclusion>
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-asm</artifactId>
+          </exclusion>   
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-beans</artifactId>
+          </exclusion> 
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-context</artifactId>
+          </exclusion> 
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-core</artifactId>
+          </exclusion>
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-expression</artifactId>
+          </exclusion>   
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-transports-http-jetty</artifactId>
         <version>${version.org.apache.cxf}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-servlet_3.0_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
@@ -993,6 +1131,68 @@
           <exclusion>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-ws-policy</artifactId>
+        <version>${cxf.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-annotation_1.0_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jaxws_2.1_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+          </exclusion>
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-asm</artifactId>
+          </exclusion>   
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-beans</artifactId>
+          </exclusion> 
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-context</artifactId>
+          </exclusion> 
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-core</artifactId>
+          </exclusion>
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-expression</artifactId>
+          </exclusion>   
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+          </exclusion>
+          <exclusion>
+             <groupId>org.springframework</groupId>
+             <artifactId>spring-jms</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-ws-security</artifactId>
+        <version>${cxf.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.soap</groupId>
+            <artifactId>saaj-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1241,6 +1441,11 @@
         <groupId>org.apache.ws.xmlschema</groupId>
         <artifactId>xmlschema-core</artifactId>
         <version>${version.org.apache.ws.xmlschema}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ws.security</groupId>
+        <artifactId>wss4j</artifactId>
+        <version>${version.org.apache.ws.security.wss4j}</version>
       </dependency>
 
       <dependency>
@@ -2216,6 +2421,28 @@
         <artifactId>weld-spi</artifactId>
         <version>${version.org.jboss.weld.weld-api}</version>
       </dependency>
+      
+       <dependency>
+        <groupId>org.jboss.ws</groupId>
+        <artifactId>jbossws-api</artifactId>
+        <version>${version.org.jboss.ws.api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.ws</groupId>
+        <artifactId>jbossws-spi</artifactId>
+        <version>${version.org.jboss.ws.spi}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.ws.cxf</groupId>
+        <artifactId>jbossws-cxf-server</artifactId>
+        <version>${version.org.jboss.ws.cxf}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.ws.cxf</groupId>
+        <artifactId>jbossws-cxf-client</artifactId>
+        <version>${version.org.jboss.ws.cxf}</version>
+      </dependency>
+      
       <dependency>
         <groupId>org.jboss.xnio</groupId>
         <artifactId>xnio-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
     <version.org.apache.commons.math3>3.2</version.org.apache.commons.math3>
     <version.org.apache.commons.ssl>0.3.9</version.org.apache.commons.ssl>
     <version.org.apache.cxf>2.7.14</version.org.apache.cxf>
+    <version.org.apache.ws.security.wss4j>1.6.17</version.org.apache.ws.security.wss4j>
     <version.org.apache.deltaspike.core>1.0.0</version.org.apache.deltaspike.core>
     <version.org.apache.ftpserver>1.0.6</version.org.apache.ftpserver>
     <version.org.apache.helix>0.6.2-incubating</version.org.apache.helix>
@@ -285,6 +286,9 @@
     <version.org.jboss.weld.weld>1.1.28.Final</version.org.jboss.weld.weld>
     <version.org.jboss.weld.weld-api>1.1.Final</version.org.jboss.weld.weld-api>
     <version.org.jboss.xnio>3.0.12.GA</version.org.jboss.xnio>
+    <version.org.jboss.ws.api>1.0.2.Final</version.org.jboss.ws.api>
+    <version.org.jboss.ws.spi>2.3.1.Final</version.org.jboss.ws.spi>
+    <version.org.jboss.ws.cxf>4.3.4.Final</version.org.jboss.ws.cxf>
     <version.org.jbpm.jbpm5.jbpmmigration>0.13</version.org.jbpm.jbpm5.jbpmmigration>
     <!-- EAP uses jdom 1.1.2 but that breaks jenkins builds with the error "Could not find artifact maven-plugins:maven-cobertura-plugin:plugin:1.3" -->
     <version.org.jdom>1.1.3</version.org.jdom>


### PR DESCRIPTION
These deps are taken from: 

http://<internal-repo>/latest/maven/org/jboss/as/jboss-as-parent/7.5.0.Final-redhat-17/jboss-as-parent-7.5.0.Final-redhat-17.pom (EAP 6.4) 
http://anonsvn.jboss.org/repos/jbossws/stack/cxf/tags/jbossws-cxf-4.3.4.Final/pom.xml (EAP 6.4 jbossws version)

bXms 6.1 will be based on EAP 6.4, and AFAICT, 6.4 is based on the 7.5.0.x build of jboss-as. 

