### PR TITLE
SWITCHYARD-2504 camel-saxon quickstart fails on Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <version.net.sf.dozer>5.4.0</version.net.sf.dozer>
     <version.net.sf.opencsv>2.3</version.net.sf.opencsv>
     <version.net.sourceforge.jtds>1.2.2</version.net.sourceforge.jtds>
-    <version.net.sf.saxon>9.5.1-2</version.net.sf.saxon>
+    <version.net.sf.saxon>9.5.1-5</version.net.sf.saxon>
     <version.org.antlr>3.5</version.org.antlr>
     <version.antlr>2.7.7</version.antlr>
     <version.org.antlr.ST4>4.0.7</version.org.antlr.ST4>


### PR DESCRIPTION
 We need a bump from saxon 9.5.1-2 to 9.5.1-5 to support Java 1.8.     This details the issues that saxon 9.5.1-*<9.5.1-5 have with Java 1.8 :+1: 

https://saxonica.plan.io/issues/1944