### PR TITLE
Added jboss-as-security and picketbox artifacts.

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1912,6 +1912,11 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-security</artifactId>
+        <version>${version.org.jboss.as}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.as</groupId>
         <artifactId>jboss-as-weld</artifactId>
         <version>${version.org.jboss.as}</version>
       </dependency>
@@ -2515,6 +2520,17 @@
         <groupId>org.mvel</groupId>
         <artifactId>mvel2</artifactId>
         <version>${version.org.mvel}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.picketbox</groupId>
+        <artifactId>picketbox</artifactId>
+        <version>${version.org.picketbox}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.picketbox</groupId>
+        <artifactId>picketbox-bare</artifactId>
+        <version>${version.org.picketbox}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,7 @@
     <!--EAP 6.4 use 4.2.0.redhat-8 which is not OSGi compatible, so stay on 4.3.1-->
     <version.org.osgi>4.3.1</version.org.osgi>
     <version.org.ops4j.pax.exam>3.5.0</version.org.ops4j.pax.exam>
+    <version.org.picketbox>4.1.1</version.org.picketbox>
     <version.org.powermock>1.5.4</version.org.powermock>
     <version.org.python>2.5.3</version.org.python>
     <version.org.quartz-scheduler>1.8.5</version.org.quartz-scheduler>


### PR DESCRIPTION
The `picketbox` version is based on what's in EAP 6.4 ER1.