### PR TITLE
Upgrade hibernate-commons-annotations from 4.0.2.Final to 4.0.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
     <version.org.hibernate.validator>4.3.1.Final</version.org.hibernate.validator>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
     <!--EAP 6.3 uses hibernate 4.0.1.Final, however 4.0.2.Final was the first to support OSGi in its manifest -->
-    <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
+    <version.org.hibernate.commons.annotations>4.0.5.Final</version.org.hibernate.commons.annotations>
     <!--EAP 6.3 use hornetq 2.3.20.Final-redhat-1, however no equiverlant in community release, so  the closest version wins-->
     <version.org.hornetq>2.3.19.Final</version.org.hornetq>
     <version.org.infinispan>5.2.10.Final</version.org.infinispan>


### PR DESCRIPTION
This version will most likely end up in EAP 6.4, so we should also upgrade. See https://bugzilla.redhat.com/show_bug.cgi?id=1184418 for more details. 

I think we can merge this once it is confirmed that the upgrade will be performed in EAP 6.4.