### PR TITLE
upgrade org.jboss.as

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
     <version.org.jboss.arquillian.container.glassfish>1.0.0.CR3</version.org.jboss.arquillian.container.glassfish>
     <version.org.jboss.arquillian.container.weld>1.0.0.CR5</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.as.arquillian>7.2.0.Final</version.org.jboss.as.arquillian>
-    <version.org.jboss.as>7.4.0.Final-redhat-19</version.org.jboss.as>
+    <version.org.jboss.as>7.5.0.Final-redhat-15</version.org.jboss.as>
     <version.org.jboss.ironjacamar>1.0.30.Final</version.org.jboss.ironjacamar>
     <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
     <version.org.jboss.jbossts.jta>4.17.29.Final</version.org.jboss.jbossts.jta>


### PR DESCRIPTION
This is a new PR about the upgrade of version.org.jboss.as from 7.4.0.Final-redhat-19 to 7.5.0.Final-redhat-17.
Normally we don't like to have any -redhat versions in jboss-ip-bom - but for this one there is an exception.