### PR TITLE
Tidy up EAP comment since the version information between EAP and jb-ip ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,14 +227,12 @@
     <version.org.eclipse.jgit>3.3.2.201404171909-r</version.org.eclipse.jgit>
     <version.org.freemarker>2.3.19</version.org.freemarker>
     <version.org.glassfish>3.1.2</version.org.glassfish>
-    <!--EAP 6.3 use hibernate 4.2.14.SP1-redhat-1, however no equiverlant in community release, so  the closest version wins-->
     <version.org.hibernate>4.2.17.Final</version.org.hibernate>
+    <!--EAP 6.4 use hibernate.search 4.4.5.Final-redhat-5-->
     <version.org.hibernate.search>4.3.0.Final</version.org.hibernate.search>
     <version.org.hibernate.validator>4.3.2.Final</version.org.hibernate.validator>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
-    <!--EAP 6.3 uses hibernate 4.0.1.Final, however 4.0.2.Final was the first to support OSGi in its manifest -->
     <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
-    <!--EAP 6.3 use hornetq 2.3.20.Final-redhat-1, however no equiverlant in community release, so  the closest version wins-->
     <version.org.hornetq>2.3.24.Final</version.org.hornetq>
     <version.org.infinispan>5.2.11.Final</version.org.infinispan>
     <!--This needs to be in sync with JUnit-->
@@ -257,7 +255,6 @@
     <version.org.jboss.marshalling>1.4.10.Final</version.org.jboss.marshalling>
     <version.org.jboss.osgi.metadata>2.2.0.Final</version.org.jboss.osgi.metadata>
     <version.org.jboss.osgi.vfs>1.2.1.Final</version.org.jboss.osgi.vfs>
-    <!--EAP 6.3 use resteasy 2.3.8.Final-redhat-3, however no equiverlant in community release, so  the closest version wins-->
     <version.org.jboss.resteasy>2.3.7.Final</version.org.jboss.resteasy>
     <version.org.jboss.forge.roaster>2.11.1.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.remote-naming>1.0.8.Final</version.org.jboss.remote-naming>
@@ -286,7 +283,6 @@
     <version.org.jboss.weld.weld-api>1.1.Final</version.org.jboss.weld.weld-api>
     <version.org.jboss.xnio>3.0.12.GA</version.org.jboss.xnio>
     <version.org.jbpm.jbpm5.jbpmmigration>0.13</version.org.jbpm.jbpm5.jbpmmigration>
-    <!-- EAP uses jdom 1.1.2 but that breaks jenkins builds with the error "Could not find artifact maven-plugins:maven-cobertura-plugin:plugin:1.3" -->
     <version.org.jdom>1.1.3</version.org.jdom>
     <version.org.jfree.jcommon>1.0.23</version.org.jfree.jcommon>
     <version.org.jfree.jfreechart>1.0.19</version.org.jfree.jfreechart>
@@ -304,6 +300,7 @@
     <version.org.mvel>2.2.2.Final</version.org.mvel>
     <version.org.objenesis>2.1</version.org.objenesis>
     <version.org.ocpsoft.prettytime>3.0.2.Final</version.org.ocpsoft.prettytime>
+    <!--EAP 6.4 use 4.2.0.redhat-8 which is not OSGi compatible, so stay on 4.3.1-->
     <version.org.osgi>4.3.1</version.org.osgi>
     <version.org.ops4j.pax.exam>3.5.0</version.org.ops4j.pax.exam>
     <version.org.powermock>1.5.4</version.org.powermock>


### PR DESCRIPTION
Tidy up EAP comment since the version information between EAP and jb-ip have changed after 6.4

To make the comment information reflect the latest status compare to EAP 6.4