### PR TITLE
Update hibernate search to 4.4.5 since EAP 6.4 is using 4.4.5.Final-redh...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
     <version.org.glassfish>3.1.2</version.org.glassfish>
     <!--EAP 6.3 use hibernate 4.2.14.SP1-redhat-1, however no equiverlant in community release, so  the closest version wins-->
     <version.org.hibernate>4.2.17.Final</version.org.hibernate>
-    <version.org.hibernate.search>4.3.0.Final</version.org.hibernate.search>
+    <version.org.hibernate.search>4.4.5.Final</version.org.hibernate.search>
     <version.org.hibernate.validator>4.3.2.Final</version.org.hibernate.validator>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
     <!--EAP 6.3 uses hibernate 4.0.1.Final, however 4.0.2.Final was the first to support OSGi in its manifest -->


### PR DESCRIPTION
...at-3

If there is no exception, we should use the same version as EAP 6.4 components.
EAP 6.4 use hibernate search 4.4.5.Final-redhat-3. 
See EAP 6.4 ER1: http://download.eng.bos.redhat.com/brewroot/repos/jb-ip-6.1-build/latest/maven/org/jboss/as/jboss-as-parent/7.5.0.Final-redhat-17/jboss-as-parent-7.5.0.Final-redhat-17.pom