### PR TITLE
Upgrade mvel 2.2.4

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -5,12 +5,12 @@
   <parent>
       <groupId>org.jboss.integration-platform</groupId>
       <artifactId>jboss-integration-platform-parent</artifactId>
-      <version>6.0.0-SNAPSHOT</version>
+      <version>6.0.0.CR25</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>jboss-integration-platform-bom</artifactId>
-  <version>6.0.0-SNAPSHOT</version>
+  <version>6.0.0.CR25</version>
   <packaging>pom</packaging>
 
   <name>JBoss Integration Platform BOM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <!-- major.minor.micro.Beta[n] -->
   <!-- major.minor.micro.CR[n] -->
   <!-- major.minor.micro.Final -->
-  <version>6.0.0-SNAPSHOT</version>
+  <version>6.0.0.CR25</version>
 
   <name>JBoss Integration Platform Parent</name>
   <description>
@@ -71,7 +71,7 @@
     <connection>scm:git:git@github.com:jboss-integration/jboss-integration-platform-bom.git</connection>
     <developerConnection>scm:git:git@github.com:jboss-integration/jboss-integration-platform-bom.git</developerConnection>
     <url>https://github.com/jboss-integration/jboss-integration-platform-bom</url>
-    <tag>HEAD</tag>
+    <tag>6.0.0.CR25</tag>
   </scm>
   <ciManagement>
     <system>hudson</system>

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
     <version.org.milyn>1.5.2</version.org.milyn>
     <version.org.mockito>1.9.5</version.org.mockito>
     <version.org.mongodb.mongo-java-driver>2.7.3</version.org.mongodb.mongo-java-driver>
-    <version.org.mvel>2.2.2.Final</version.org.mvel>
+    <version.org.mvel>2.2.4.Final</version.org.mvel>
     <version.org.objenesis>2.1</version.org.objenesis>
     <version.org.ocpsoft.prettytime>3.0.2.Final</version.org.ocpsoft.prettytime>
     <version.org.osgi>4.3.1</version.org.osgi>


### PR DESCRIPTION
This is for upgrade mvel to 2.2.4.Final from 2.2.2.Final since droolsjbpm start to use 2.2.4.Final.
Let's make this consistent across jboss products/