### PR TITLE
Remove ironjacamar artifacts since it's shipped  in IP products

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1712,36 +1712,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.jboss.ironjacamar</groupId>
-        <artifactId>ironjacamar-core-api</artifactId>
-        <version>${version.org.jboss.ironjacamar}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.ironjacamar</groupId>
-        <artifactId>ironjacamar-embedded</artifactId>
-        <version>${version.org.jboss.ironjacamar}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.ironjacamar</groupId>
-        <artifactId>ironjacamar-deployers-fungal</artifactId>
-        <version>${version.org.jboss.ironjacamar}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.ironjacamar</groupId>
-        <artifactId>ironjacamar-deployers-common</artifactId>
-        <version>${version.org.jboss.ironjacamar}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.ironjacamar</groupId>
-        <artifactId>ironjacamar-common-impl-papaki</artifactId>
-        <version>${version.org.jboss.ironjacamar}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.ironjacamar</groupId>
-        <artifactId>ironjacamar-jdbc</artifactId>
-        <version>${version.org.jboss.ironjacamar}</version>
-      </dependency>
-      <dependency>
         <groupId>org.jboss.osgi.metadata</groupId>
         <artifactId>jbosgi-metadata</artifactId>
         <version>${version.org.jboss.osgi.metadata}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,6 @@
     <version.org.jboss.arquillian.container.weld>1.0.0.CR5</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.as.arquillian>7.2.0.Final</version.org.jboss.as.arquillian>
     <version.org.jboss.as>7.5.0.Final-redhat-15</version.org.jboss.as>
-    <version.org.jboss.ironjacamar>1.0.30.Final</version.org.jboss.ironjacamar>
     <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
     <version.org.jboss.jbossts.jta>4.17.29.Final</version.org.jboss.jbossts.jta>
     <version.org.jboss.jbossts.xts>4.17.29.Final</version.org.jboss.jbossts.xts>


### PR DESCRIPTION
Discussed in ip-dev ,the ironjacamar artifacts are not shipped in IP products. They are only test artifacts for Modeshape project. So it should be good to remove them from ip bom . This will remove the efforts to synchronize the ironjacamar version with EAP or other if applicable.