### PR TITLE
Added org.apache.httpcomponents:fluent-hc dependency

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1232,6 +1232,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>fluent-hc</artifactId>
+        <version>${version.org.apache.httpcomponents.httpclient}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
         <version>${version.org.apache.httpcomponents.httpcore}</version>
       </dependency>


### PR DESCRIPTION
As of the 4.2 release of httpcomponents, they have a fluent interface (documentation [here](http://hc.apache.org/httpcomponents-client-ga/tutorial/html/fluent.html)) which is easier to use and which KIE/drools/jbpm would like to use in the integration tests. 

