### PR TITLE
changed version name

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1137,7 +1137,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-ws-policy</artifactId>
-        <version>${cxf.version}</version>
+        <version>${version.org.apache.cxf}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1184,7 +1184,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-ws-security</artifactId>
-        <version>${cxf.version}</version>
+        <version>${version.org.apache.cxf}</version>
         <exclusions>
           <exclusion>
             <groupId>javax.xml.soap</groupId>


### PR DESCRIPTION
since cxf.version is not any more declared in jboss-integration-platform-bom/pom-xml two artifacts in jboss-integration-platform-bom/ip-bom/pom-xml that were still using this version had to be modified to use version.org.apache.cxf
