### PR TITLE
upgrade resteasy from 2.3.7.Final to 2.3.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
     <version.org.jboss.marshalling>1.4.10.Final</version.org.jboss.marshalling>
     <version.org.jboss.osgi.metadata>2.2.0.Final</version.org.jboss.osgi.metadata>
     <version.org.jboss.osgi.vfs>1.2.1.Final</version.org.jboss.osgi.vfs>
-    <version.org.jboss.resteasy>2.3.7.Final</version.org.jboss.resteasy>
+    <version.org.jboss.resteasy>2.3.10.Final</version.org.jboss.resteasy>
     <version.org.jboss.forge.roaster>2.11.1.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.remote-naming>1.0.8.Final</version.org.jboss.remote-naming>
     <version.org.jboss.remoting3>3.3.4.Final</version.org.jboss.remoting3>


### PR DESCRIPTION
alignment to EAP 6.4:
In EAP 6.4 it is used resteasy 2.3.10.Final-redhat-1.