### PR TITLE
Added dep mgmt for org.hibernate:hibernate-jpamodelgen

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1810,6 +1810,11 @@
         <artifactId>hibernate-jpa-2.0-api</artifactId>
         <version>${version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api}</version>
       </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-jpamodelgen</artifactId>
+        <version>${version.org.hibernate.jpamodelgen}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.hsqldb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,9 @@
     <version.org.hibernate.validator>4.3.2.Final</version.org.hibernate.validator>
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
     <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
+    <!-- version.org.hibernate.jpamodelgen should be removed and version.org.hibernate used instead 
+         once we move to hibernaate 4.3+ -->
+    <version.org.hibernate.jpamodelgen>1.3.0.Final</version.org.hibernate.jpamodelgen>
     <version.org.hornetq>2.3.25.Final</version.org.hornetq>
     <version.org.infinispan>5.2.11.Final</version.org.infinispan>
     <!--This needs to be in sync with JUnit-->


### PR DESCRIPTION
jBPM will be starting to use the Criteria API in community 6.3+, and the jpa-modelgen is a helpful tooling jar for that. 