### PR TITLE
SWITCHYARD-2624 Upgrade integration-platform-bom to use Camel 2.15.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.com.oracle.ojdbc14>10.2.0.4.0</version.com.oracle.ojdbc14>
     <version.com.smartgwt.smartgwt-skins>2.4</version.com.smartgwt.smartgwt-skins>
-    <version.com.sun.xml.bind>2.2.5</version.com.sun.xml.bind>
+    <version.com.sun.xml.bind>2.2.11</version.com.sun.xml.bind>
     <version.com.thoughtworks.xstream>1.4.7</version.com.thoughtworks.xstream>
     <version.dom4j>1.6.1</version.dom4j>
     <version.io.netty>3.6.9.Final</version.io.netty>
@@ -172,7 +172,7 @@
     <version.org.apache.activemq>5.8.0</version.org.apache.activemq>
     <version.org.apache.ant>1.8.2</version.org.apache.ant>
     <version.org.apache.aries.blueprint>1.0.0</version.org.apache.aries.blueprint>
-    <version.org.apache.camel>2.14.0</version.org.apache.camel>
+    <version.org.apache.camel>2.15.2</version.org.apache.camel>
     <version.org.apache.chemistry.opencmis>0.11.0</version.org.apache.chemistry.opencmis>
     <version.org.apache.commons.compress>1.4.1</version.org.apache.commons.compress>
     <version.org.apache.commons.exec>1.0.1</version.org.apache.commons.exec>


### PR DESCRIPTION
Upgrading camel version to 2.15.2. Also update com.sun.xml.bind from 2.2.5 to 2.2.11 to avoid JAXB related issue camel-2.15 hit.