### PR TITLE
Upgrade illegal-transitive-dependency-check from 1.7.2 to 1.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
           <dependency>
             <groupId>de.is24.maven.enforcer.rules</groupId>
             <artifactId>illegal-transitive-dependency-check</artifactId>
-            <version>1.7.2</version>
+            <version>1.7.4</version>
           </dependency>
           <dependency>
             <groupId>com.redhat.victims</groupId>


### PR DESCRIPTION
 * 1.7.4 adds the possibility to exclude whole classes from the
   check (e.g. generated Errai marshalling classes)