### PR TITLE
upgraded to <version.org.apache.cxf>2.7.16 to align with EAP 6.4.2

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1201,6 +1201,16 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-bindings-xml</artifactId>
+        <version>${version.org.apache.cxf}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-ws-addr</artifactId>
+        <version>${version.org.apache.cxf}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.apache.deltaspike.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <version.org.apache.commons.math>2.1</version.org.apache.commons.math>
     <version.org.apache.commons.math3>3.2</version.org.apache.commons.math3>
     <version.org.apache.commons.ssl>0.3.9</version.org.apache.commons.ssl>
-    <version.org.apache.cxf>2.7.14</version.org.apache.cxf>
+    <version.org.apache.cxf>2.7.16</version.org.apache.cxf>
     <version.org.apache.ws.security.wss4j>1.6.17</version.org.apache.ws.security.wss4j>
     <version.org.apache.deltaspike.core>1.0.0</version.org.apache.deltaspike.core>
     <version.org.apache.ftpserver>1.0.6</version.org.apache.ftpserver>


### PR DESCRIPTION
EAP 6.4.2 uses org.apache.cxf:cxf-api:2.7.16