### PR TITLE
downgrade xts to 4.17.29.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
     <version.org.jboss.as>7.5.2.Final-redhat-2</version.org.jboss.as>
     <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
     <version.org.jboss.jbossts.jta>4.17.29.Final</version.org.jboss.jbossts.jta>
-    <version.org.jboss.jbossts.xts>4.17.30.Final</version.org.jboss.jbossts.xts>
+    <version.org.jboss.jbossts.xts>4.17.29.Final</version.org.jboss.jbossts.xts>
     <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.logging.jboss-logging-processor>1.1.0.Final</version.org.jboss.logging.jboss-logging-processor>
     <version.org.jboss.marshalling>1.4.10.Final</version.org.jboss.marshalling>


### PR DESCRIPTION
Downgrade <version.org.jboss.jbossts.xts> from 4.17.30.Final to 4.17.29.Final.    

There is no publicly released maven artifact for jbossxts-4.17.30.Final.jar, but there is a jbossxts-4.17.29.Final.jar.    The requirement for 4.17.30.Final is causing build issues on SwitchYard's end. 

Note : there is a jbossxts-4.17.30.Final-redhat-1.jar but I don't believe we're supposed to use product releases here in the BOM, especially ones that don't exist in public repositories.