### PR TITLE
added jcip-annotations to align with EAP 6.4.3

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -507,6 +507,12 @@
       </dependency>
 
       <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>${version.net.jcip}</version>
+      </dependency>
+
+      <dependency>
         <groupId>net.sf.dozer</groupId>
         <artifactId>dozer</artifactId>
         <version>${version.net.sf.dozer}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
     <version.junit>4.11</version.junit>
     <version.mc4j>1.3</version.mc4j>
     <version.mysql.connector-java>5.1.22</version.mysql.connector-java>
+    <version.net.jcip>1.0</version.net.jcip>
     <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>
     <version.net.sf.dozer>5.4.0</version.net.sf.dozer>
     <version.net.sf.opencsv>2.3</version.net.sf.opencsv>


### PR DESCRIPTION
this artifact is in EAP 6.4.3, 
is NOT in jboss-ip-bom
is in kie-platform-bom 
so we decide to remove it from kie-platform-bom and add it to jboss-ip-bom