### PR TITLE
Add test that checks availability of the ip-bom deps

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ By inheriting the jboss-integration-platform-parent:
 
 * The properties used by the BOM are visible to the project.
 
-* It inherits from org.jboss:jboss-parent:10.
+* It inherits from org.jboss:jboss-parent:16.
 
 * Any further plugin alignments (e.g. GWT) may be done here.
 
@@ -168,3 +168,10 @@ This section records which project/product versions use which bom version.
 ** Products
 
 *** BRMS 6.0
+
+=== Testing
+Directory `ip-bom-deps-available-test` contains simple Bash script that can be used to verify that all the dependencies
+declared in `<dependencyManagement` are actually available (downloadable). The script copies the ip-bom, removes the
+`<dependencyManagement>` XML elements and runs Maven build to see if all the dependencies can be resolved. If there
+are dependencies not available in any of the following repositories the build will fail. Those repositories are
+Maven Central, JBoss.org Nexus or Red Hat Public Product Repo.

--- a/ip-bom-deps-available-test/.gitignore
+++ b/ip-bom-deps-available-test/.gitignore
@@ -1,0 +1,17 @@
+/target
+/local
+
+# pom.xml is generated during test run
+pom.xml
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+!.gitattributes
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store

--- a/ip-bom-deps-available-test/ip-bom-deps-available-test-settings.xml
+++ b/ip-bom-deps-available-test/ip-bom-deps-available-test-settings.xml
@@ -1,0 +1,43 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository/>
+  <interactiveMode/>
+  <usePluginRegistry/>
+  <offline/>
+  <pluginGroups/>
+  <servers/>
+  <mirrors/>
+  <proxies/>
+  <profiles>
+    <profile>
+      <id>jboss-repos</id>
+      <repositories>
+        <repository>
+          <id>jboss-public-repo</id>
+          <url>https://repository.jboss.org/nexus/content/groups/public</url>
+        </repository>
+        <repository>
+          <id>jboss-product-repo</id>
+          <url>https://maven.repository.redhat.com/ga</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>jboss-public-repo</id>
+          <url>https://repository.jboss.org/nexus/content/groups/public</url>
+        </pluginRepository>
+        <pluginRepository>
+          <id>jboss-product-repo</id>
+          <url>https://maven.repository.redhat.com/ga</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>jboss-repos</activeProfile>
+  </activeProfiles>
+
+</settings>

--- a/ip-bom-deps-available-test/run-deps-available-test.sh
+++ b/ip-bom-deps-available-test/run-deps-available-test.sh
@@ -1,0 +1,25 @@
+#!/bin/env sh
+
+# Runs a test which verifies that all dependencies inside ip-bom's <dependencyManagement> are available (downloadable).
+#
+# Test copies current ip-bom, removes the <dependencyManagement> XML elements and tries to resolve all the dependencies using
+# "clean dependency:tree" Maven build. In case one of the dependencies is not available the build fails.
+
+
+# Determine and use the current script dir, so that the script can be called from any working directroy and still work correctly
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+rm -f ${SCRIPT_DIR}/pom.xml
+cp  ${SCRIPT_DIR}/../ip-bom/pom.xml ${SCRIPT_DIR}/pom.xml
+
+sed -i 's/jboss-integration-platform-bom/jboss-integration-platform-bom-deps-available-test/g' ${SCRIPT_DIR}/pom.xml
+sed -i 's/Platform BOM/Platform BOM - Dependencies Available Test/g' ${SCRIPT_DIR}/pom.xml
+# Remove  dependencyManagement XML elements
+sed -i 's/<dependencyManagement>//g' ${SCRIPT_DIR}/pom.xml
+sed -i 's/<\/dependencyManagement>//g' ${SCRIPT_DIR}/pom.xml
+# Remove 'import' scope from the imported BOMs to avoid Maven warnings ('import' scope is only valid inside depMgmt section)
+sed -i 's/<scope>import<\/scope>//g' ${SCRIPT_DIR}/pom.xml
+
+# Run the build with disabled enforcer to avoid failures for 'no-managed-deps' rule (versions of dependencies in this test POM
+# are not managed)
+mvn -f ${SCRIPT_DIR}/pom.xml -B -e clean dependency:tree -Denforcer.skip=true -s ${SCRIPT_DIR}/ip-bom-deps-available-test-settings.xml $@


### PR DESCRIPTION
This PR does not change or add any dependency. It only contains a simple test to make sure all the dependencies in the `dependencyManagement` section are available (downloadable). I wanted to get some feedback before merging this in.

The plan is to create a Jenkins job which would execute this test for every new PR, to make sure ip-bom contains only dependencies that are actually available.