### PR TITLE
Upgrade Apache POI from 3.10.1 to 3.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
     <version.org.apache.maven.wagon.http>2.6</version.org.apache.maven.wagon.http>
     <version.org.apache.mina>2.0.7</version.org.apache.mina>
     <version.org.apache.neethi>3.0.2</version.org.apache.neethi>
-    <version.org.apache.poi>3.10.1</version.org.apache.poi>
+    <version.org.apache.poi>3.13</version.org.apache.poi>
     <version.org.apache.qpid>0.18</version.org.apache.qpid>
     <version.org.apache.sshd>0.12.0</version.org.apache.sshd>
     <version.org.apache.tika>1.3</version.org.apache.tika>


### PR DESCRIPTION
The main reason for this change is to get rid of `dom4j` dependency. Version `3.10.1` depends on it, but it the dependency was removed in `3.13` (or maybe in earlier version). `dom4j` brings additional xml-related deps which then leads to duplicated classes with same FQN:

Dependency tree of version `3.10.1`:
```
[INFO] +- org.apache.poi:poi-ooxml:jar:3.10.1:compile
[INFO] |  +- org.apache.poi:poi-ooxml-schemas:jar:3.10.1:compile
[INFO] |  |  \- org.apache.xmlbeans:xmlbeans:jar:2.3.0:compile
[INFO] |  |     \- stax:stax-api:jar:1.0.1:compile
[INFO] |  \- dom4j:dom4j:jar:1.6.1:compile
[INFO] |     \- xml-apis:xml-apis:jar:1.3.04:compile
[INFO] +- org.apache.poi:poi:jar:3.10.1:compile
```

And the duplicated classes found:
```
Duplicate classes found:

  Found in:
    org.apache.xmlbeans:xmlbeans:jar:2.3.0:compile
    xml-apis:xml-apis:jar:1.3.04:compile
  Duplicate classes:
    org/w3c/dom/UserDataHandler.class
    org/w3c/dom/TypeInfo.class
    org/w3c/dom/DOMConfiguration.class
    org/w3c/dom/DOMStringList.class

  Found in:
    stax:stax-api:jar:1.0.1:compile
    xml-apis:xml-apis:jar:1.3.04:compile
  Duplicate classes:
    javax/xml/namespace/NamespaceContext.class
    javax/xml/XMLConstants.class
    javax/xml/namespace/QName.class
```