### PR TITLE
Exclude javax.transaction:jta from Bitronix

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1572,6 +1572,12 @@
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm</artifactId>
         <version>${version.org.codehaus.btm}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.transaction</groupId>
+            <artifactId>jta</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.codehaus.btm</groupId>


### PR DESCRIPTION
 * IP projects should be using JBoss Spec jars and not the different javax.* jars.
   This fixes the issue at top-level, so it does not need to be done individually
   at project levels.