### PR TITLE
Exclude javax.annotation:jsr250-api from weld-core and weld-se-core

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -2509,11 +2509,23 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core</artifactId>
         <version>${version.org.jboss.weld.weld}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>jsr250-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.weld.se</groupId>
         <artifactId>weld-se-core</artifactId>
         <version>${version.org.jboss.weld.weld}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>jsr250-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.weld.servlet</groupId>


### PR DESCRIPTION
 * jboss-annotations-api_1.1_spec should be use instead