### PR TITLE
Upgrade jboss-parent from 16 to 19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>16</version>
+    <version>19</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
This is the complete diff between version 16 and 19. Bunch of plugin updates + few additional fixes.
https://github.com/jboss/jboss-parent-pom/compare/jboss-parent-16...jboss-parent-19

The reason I am proposing this change is to get rid of some of the local overrides we have in our parent, since they are already present in the jboss-parent. I believe this should be a safe change, but it would be probably a good idea to try this locally with our projects, just to be sure.