### PR TITLE
Upgrade mocking deps to make them compatible with JDK8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <version.com.google.guava>13.0.1</version.com.google.guava>
     <version.com.google.gwt>2.5.1</version.com.google.gwt>
     <version.org.google.gwt-charts>0.9.9</version.org.google.gwt-charts>
-    <version.com.google.gwt.gwtmockito>1.1.3</version.com.google.gwt.gwtmockito>
+    <version.com.google.gwt.gwtmockito>1.1.5</version.com.google.gwt.gwtmockito>
     <version.org.google.gwt.visualization>1.0.2</version.org.google.gwt.visualization>
     <version.com.google.javascript.closure-compiler>r1741</version.com.google.javascript.closure-compiler>
     <version.com.google.protobuf>2.5.0</version.com.google.protobuf>
@@ -306,7 +306,7 @@
     <version.log4j>1.2.17</version.log4j>
     <version.ognl>3.0.6</version.ognl>
     <version.org.milyn>1.5.2</version.org.milyn>
-    <version.org.mockito>1.9.5</version.org.mockito>
+    <version.org.mockito>1.10.19</version.org.mockito>
     <version.org.mongodb.mongo-java-driver>2.7.3</version.org.mongodb.mongo-java-driver>
     <version.org.mvel>2.2.7.Final</version.org.mvel>
     <version.org.objenesis>2.1</version.org.objenesis>
@@ -315,7 +315,7 @@
     <version.org.osgi>4.3.1</version.org.osgi>
     <version.org.ops4j.pax.exam>4.3.0</version.org.ops4j.pax.exam>
     <version.org.picketbox>4.1.1.Final</version.org.picketbox>
-    <version.org.powermock>1.5.4</version.org.powermock>
+    <version.org.powermock>1.6.3</version.org.powermock>
     <version.org.python>2.5.3</version.org.python>
     <version.org.quartz-scheduler>1.8.5</version.org.quartz-scheduler>
     <version.org.reflections>0.9.10</version.org.reflections>


### PR DESCRIPTION
 * new versions are still JDK6 compatible (verified by `javap -v <class-from-jar>` and looking at major version)
 * these mocking libraries have inter-dependencies,
   so it wasn't possible to ugprade just powermock
   (as that was the one causing issues on JDK8). These
   versions are known to work together