### PR TITLE
Exclude log4j coming from helix-core

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1230,6 +1230,12 @@
         <groupId>org.apache.helix</groupId>
         <artifactId>helix-core</artifactId>
         <version>${version.org.apache.helix}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -351,8 +351,6 @@
     <version.xmlpull>1.1.3.1</version.xmlpull>
     <version.xmlunit>1.3</version.xmlunit>
     <version.xpp3>1.1.4c</version.xpp3>
-
-
   </properties>
 
   <build>


### PR DESCRIPTION
 * libraries should not depend on specific logging
   implementations, but rather logging API (like SLF4J)
   and the user's of those libs pick the actual
   implementation (be it logback, log4j or JUL).

There are probably other jars which drag in log4j, perhaps we should exclude the log4j from all those as well (as a subsequent PR)....