### PR TITLE
Upgrade version to 7.0.0-SNAPSHOT + set source/target levels to Java 8

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
       <groupId>org.jboss.integration-platform</groupId>
       <artifactId>jboss-integration-platform-parent</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>7.0.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <!-- major.minor.micro.Beta[n] -->
   <!-- major.minor.micro.CR[n] -->
   <!-- major.minor.micro.Final -->
-  <version>6.0.1-SNAPSHOT</version>
+  <version>7.0.0-SNAPSHOT</version>
 
   <name>JBoss Integration Platform Parent</name>
   <description>
@@ -91,9 +91,9 @@
     <victims.updates>weekly</victims.updates>
     <illegaltransitivereportonly>false</illegaltransitivereportonly>
 
-    <!-- Override Java source/target to be 1.6 -->
-    <maven.compiler.target>1.6</maven.compiler.target>
-    <maven.compiler.source>1.6</maven.compiler.source>
+    <!-- Override Java source/target comming from jboss-parent -->
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
 
     <!--
       CONVENTIONS:


### PR DESCRIPTION
 * this means the IP BOM will be buildable only by Java 8+

Once merged, I will create 6.0.x branch which would be the same as master, minus this commit.