### PR TITLE
Upgrade org.javassist:javassist to 3.18.2-GA to fix issue on Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>
     <version.org.jasypt.jasypt>1.9.0</version.org.jasypt.jasypt>
-    <version.org.javassist>3.18.1-GA</version.org.javassist>
+    <version.org.javassist>3.18.2-GA</version.org.javassist>
     <version.org.jaudiotagger>2.0.3</version.org.jaudiotagger>
     <version.org.jboss.arquillian>1.1.9.Final</version.org.jboss.arquillian>
     <version.org.jboss.arquillian.container.glassfish>1.0.0.CR3</version.org.jboss.arquillian.container.glassfish>


### PR DESCRIPTION
 * version 3.18.2-GA fixes the issue described in http://stackoverflow.com/questions/30313255/reflections-java-8-invalid-constant-type

EAP uses different version, but we really need this fix in. I will talk to WildFly/EAP guys if they could upgrade as well, so that we would be aligned.