### PR TITLE
Upgrade Camel from 2.15.2 to 2.16.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
     <version.org.apache.activemq>5.8.0</version.org.apache.activemq>
     <version.org.apache.ant>1.8.2</version.org.apache.ant>
     <version.org.apache.aries.blueprint>1.0.0</version.org.apache.aries.blueprint>
-    <version.org.apache.camel>2.15.2</version.org.apache.camel>
+    <version.org.apache.camel>2.16.2</version.org.apache.camel>
     <version.org.apache.chemistry.opencmis>0.11.0</version.org.apache.chemistry.opencmis>
     <version.org.apache.commons.compress>1.4.1</version.org.apache.commons.compress>
     <version.org.apache.commons.exec>1.3</version.org.apache.commons.exec>


### PR DESCRIPTION
Upgrade the version of Camel from 2.15.2 to 2.16.2 on the 6.0.x branch.