### PR TITLE
BZ-1309248 Add keycloak into jboss-integration-bom

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -2747,6 +2747,48 @@
       </dependency>
 
       <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-parent</artifactId>
+        <type>pom</type>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-core</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-adapter-core</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-servlet-oauth-client</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-model-api</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-account-api</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-events-api</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-admin-client</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+
+      <dependency>
          <groupId>org.littleshoot</groupId>
          <artifactId>littleproxy</artifactId>
          <version>${version.org.littleshoot.littleproxy}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,7 @@
     <version.org.json>20090211</version.org.json>
     <version.org.jsoup>1.8.3</version.org.jsoup>
     <version.org.jvnet.mock-javamail>1.9</version.org.jvnet.mock-javamail>
+    <version.org.keycloak>1.8.0.Final</version.org.keycloak>
     <version.org.littleshoot.littleproxy>0.5.3</version.org.littleshoot.littleproxy>
     <version.log4j>1.2.17</version.log4j>
     <version.ognl>3.0.6</version.ognl>


### PR DESCRIPTION
As far as I know, at least errai and uberfire-extensions are using keycloak.
It should be easier to keep keycloak version consistent between jboss-integration projects.