### PR TITLE
upgraded version.org.beanshell from 2.0b5 to 2.0b6

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1620,9 +1620,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.beanshell</groupId>
+        <groupId>org.apache-extras.beanshell</groupId>
         <artifactId>bsh</artifactId>
-        <version>${version.org.beanshell}</version>
+        <version>${version.org.apache-extras.beanshell}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <version.org.apache.xmlgraphics.batik>1.7</version.org.apache.xmlgraphics.batik>
     <!-- Only AssertJ 1.x is Java 6 compatible; 2.x and higher requires Java 7 -->
     <version.org.assertj>1.7.1</version.org.assertj>
-    <version.org.beanshell>2.0b5</version.org.beanshell>
+    <version.org.apache-extras.beanshell>2.0b6</version.org.apache-extras.beanshell>
     <version.org.clojure>1.3.0-alpha5</version.org.clojure>
     <version.org.cobogw.gwt>1.0</version.org.cobogw.gwt>
     <version.org.codehaus.btm>2.1.4</version.org.codehaus.btm>


### PR DESCRIPTION
this will fix the BZ 1312172 and 1312175
we have should release the next jboss-ip-bpm 6.0.3.Final to have this fix in the next 6.4.x release