### PR TITLE
Upgrade commons-math3 from 3.2 to 3.4.1 (Backport PR)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <version.org.apache.commons.exec>1.3</version.org.apache.commons.exec>
     <version.org.apache.commons.lang3>3.1</version.org.apache.commons.lang3>
     <version.org.apache.commons.math>2.1</version.org.apache.commons.math>
-    <version.org.apache.commons.math3>3.2</version.org.apache.commons.math3>
+    <version.org.apache.commons.math3>3.4.1</version.org.apache.commons.math3>
     <version.org.apache.commons.ssl>0.3.9</version.org.apache.commons.ssl>
     <version.org.apache.cxf>2.7.18</version.org.apache.cxf>
     <version.org.apache.ws.security.wss4j>1.6.19</version.org.apache.ws.security.wss4j>


### PR DESCRIPTION
(cherry picked from commit f9bb985797cfee9f3f407cba3e371e374a9c140d)