### PR TITLE
Upgrade commons-collections from 3.2.1 to 3.2.2 to avoid CVE-2015-8103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <version.ch.qos.logback>1.0.9</version.ch.qos.logback>
     <version.commons-cli>1.2</version.commons-cli>
     <version.commons-codec>1.4</version.commons-codec>
-    <version.commons-collections>3.2.1</version.commons-collections>
+    <version.commons-collections>3.2.2</version.commons-collections>
     <version.commons-configuration>1.6</version.commons-configuration>
     <version.commons-dbcp>1.4</version.commons-dbcp>
     <version.commons-digester>1.8</version.commons-digester>


### PR DESCRIPTION
(cherry picked from commit ae4b6bfc562751d53fe2caa1695ccb743841787a)