### PR TITLE
[6.0.x] Upgrade org.apache.aries.blueprint deps

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -686,17 +686,17 @@
       <dependency>
         <groupId>org.apache.aries.blueprint</groupId>
         <artifactId>org.apache.aries.blueprint.api</artifactId>
-        <version>${version.org.apache.aries.blueprint}</version>
+        <version>${version.org.apache.aries.blueprint.api}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.aries.blueprint</groupId>
         <artifactId>org.apache.aries.blueprint.noosgi</artifactId>
-        <version>${version.org.apache.aries.blueprint}</version>
+        <version>${version.org.apache.aries.blueprint.noosgi}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.aries.blueprint</groupId>
         <artifactId>blueprint-parser</artifactId>
-        <version>${version.org.apache.aries.blueprint}</version>
+        <version>${version.org.apache.aries.blueprint.parser}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,9 @@
     <version.org.apache.abdera>1.1.3</version.org.apache.abdera>
     <version.org.apache.activemq>5.8.0</version.org.apache.activemq>
     <version.org.apache.ant>1.8.3</version.org.apache.ant>
-    <version.org.apache.aries.blueprint>1.0.0</version.org.apache.aries.blueprint>
+    <version.org.apache.aries.blueprint.api>1.0.1</version.org.apache.aries.blueprint.api>
+    <version.org.apache.aries.blueprint.noosgi>1.1.1</version.org.apache.aries.blueprint.noosgi>
+    <version.org.apache.aries.blueprint.parser>1.4.0</version.org.apache.aries.blueprint.parser>
     <version.org.apache.camel>2.16.2</version.org.apache.camel>
     <version.org.apache.chemistry.opencmis>0.11.0</version.org.apache.chemistry.opencmis>
     <version.org.apache.commons.compress>1.4.1</version.org.apache.commons.compress>


### PR DESCRIPTION
 * these versions are used in Fuse 6.2.x