### PR TITLE
BPMSPL-282 to exclude xmlpull and xpp3_min

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -347,6 +347,16 @@
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
         <version>${version.com.thoughtworks.xstream}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xpp3_min</groupId>
+            <artifactId>xpp3_min</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xmlpull</groupId>
+            <artifactId>xmlpull</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -3217,12 +3227,6 @@
       </dependency>
 
       <dependency>
-        <groupId>xmlpull</groupId>
-        <artifactId>xmlpull</artifactId>
-        <version>${version.xmlpull}</version>
-      </dependency>
-
-      <dependency>
         <groupId>xmlunit</groupId>
         <artifactId>xmlunit</artifactId>
         <version>${version.xmlunit}</version>
@@ -3230,7 +3234,7 @@
 
       <dependency>
         <groupId>xpp3</groupId>
-        <artifactId>xpp3_min</artifactId>
+        <artifactId>xpp3</artifactId>
         <version>${version.xpp3}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,6 @@
     <version.xerces>2.9.1</version.xerces>
     <version.xml-apis>1.3.04</version.xml-apis>
     <version.xml-resolver>1.2</version.xml-resolver>
-    <version.xmlpull>1.1.3.1</version.xmlpull>
     <version.xmlunit>1.3</version.xmlunit>
     <version.xpp3>1.1.4c</version.xpp3>
   </properties>


### PR DESCRIPTION
This is for exclude xmlpull and using xpp3 instead.
Basically it's very hard to productize xmlpull and xmlpull api is included in xpp3.
The best way is to exclude xmlpull from xstream's depenendcies somehow.
Please see detail discussion in https://issues.jboss.org/browse/BPMSPL-282