### PR TITLE
Upgrade Logback from 1.0.9 to 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <version.asm>3.3.1</version.asm>
     <version.ca.uhn.hapi>2.1</version.ca.uhn.hapi>
     <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
-    <version.ch.qos.logback>1.0.9</version.ch.qos.logback>
+    <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
     <version.commons-cli>1.2</version.commons-cli>
     <version.commons-codec>1.10</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>


### PR DESCRIPTION
 * 1.1.3 depends on slf4j-api 1.7.7
   (used by ip-bom as well)