### PR TITLE
Upgrade GwtMockito to 1.1.6

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -252,15 +252,6 @@
         <groupId>com.google.gwt.gwtmockito</groupId>
         <artifactId>gwtmockito</artifactId>
         <version>${version.com.google.gwt.gwtmockito}</version>
-        <exclusions>
-          <!-- mockito-all is ugly uberjar. Users of gwtmockito need to depend on on mockito-core explicitly.
-               Once we upgrade gwtmockito to version that contains https://github.com/google/gwtmockito/pull/56, this
-               exclude can be removed, as wel as explit dependencies on mockito-core. -->
-          <exclusion>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.gwt.google-apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <version.com.google.guava>18.0</version.com.google.guava>
     <version.com.google.gwt>2.5.1</version.com.google.gwt>
     <version.org.google.gwt-charts>0.9.9</version.org.google.gwt-charts>
-    <version.com.google.gwt.gwtmockito>1.1.5</version.com.google.gwt.gwtmockito>
+    <version.com.google.gwt.gwtmockito>1.1.6</version.com.google.gwt.gwtmockito>
     <version.org.google.gwt.visualization>1.0.2</version.org.google.gwt.visualization>
     <version.com.google.javascript.closure-compiler>r1741</version.com.google.javascript.closure-compiler>
     <version.com.google.protobuf>2.6.0</version.com.google.protobuf>


### PR DESCRIPTION
GwtMockito 1.1.6 allows removal of temporary exclusion https://github.com/jboss-integration/jboss-integration-platform-bom/blob/master/ip-bom/pom.xml#L256. See https://github.com/google/gwtmockito#version-history

Furthermore GwtMockito 1.1.6 supports use of a prototype JUnit Test Runner (see https://github.com/romartin/lienzo-mockito); needed for Drools 7.x unit tests.