### PR TITLE
Upgrade JAXRS API from 1.1 to 2.0 + RestEasy from 2.3.10.Final to 3.0.16.Final

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -2228,11 +2228,6 @@
 
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
-        <artifactId>jaxrs-api</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-atom-provider</artifactId>
         <version>${version.org.jboss.resteasy}</version>
       </dependency>
@@ -2304,11 +2299,6 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>tjws</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-test-tjws</artifactId>
         <version>${version.org.jboss.resteasy}</version>
       </dependency>
 
@@ -2442,8 +2432,8 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.ws.rs</groupId>
-        <artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_1.1_spec}</version>
+        <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.0_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.xml.ws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
     <version.org.jboss.marshalling>1.4.10.Final</version.org.jboss.marshalling>
     <version.org.jboss.osgi.metadata>2.2.0.Final</version.org.jboss.osgi.metadata>
     <version.org.jboss.osgi.vfs>1.2.1.Final</version.org.jboss.osgi.vfs>
-    <version.org.jboss.resteasy>2.3.10.Final</version.org.jboss.resteasy>
+    <version.org.jboss.resteasy>3.0.16.Final</version.org.jboss.resteasy>
     <version.org.jboss.forge.roaster>2.13.0.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.remote-naming>2.0.4.Final</version.org.jboss.remote-naming>
     <version.org.jboss.remoting3>3.3.7.Final</version.org.jboss.remoting3>
@@ -292,7 +292,7 @@
     <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec>
     <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.1.2.Final</version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>
-    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_1.1_spec>
+    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.0_spec>
     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
     <version.org.jboss.solder>3.2.1.Final</version.org.jboss.solder>


### PR DESCRIPTION
* these are the versions used by WFLY10/EAP7