### PR TITLE
Align several 'org.jboss.spec.javax.*' deps with WFLY10/EAP7

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -376,11 +376,6 @@
         <artifactId>activation</artifactId>
         <version>${version.javax.activation}</version>
       </dependency>
-      <dependency>
-        <groupId>org.jboss.spec.javax.annotation</groupId>
-        <artifactId>jboss-annotations-api_1.1_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.1_spec}</version>
-      </dependency>
       <!-- javax.ejb is specified by org.jboss.spec.javax.ejb-->
       <!-- javax.el is specified by org.jboss.spec.javax.el-->
       <dependency>
@@ -2381,44 +2376,49 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss.spec.javax.annotation</groupId>
+        <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.spec.javax.ejb</groupId>
-        <artifactId>jboss-ejb-api_3.1_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec}</version>
+        <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.el</groupId>
-        <artifactId>jboss-el-api_2.2_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec}</version>
+        <artifactId>jboss-el-api_3.0_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.interceptor</groupId>
-        <artifactId>jboss-interceptors-api_1.1_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.interceptor}</version>
+        <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.jms</groupId>
-        <artifactId>jboss-jms-api_1.1_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.jms}</version>
+        <artifactId>jboss-jms-api_2.0_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.resource</groupId>
-        <artifactId>jboss-connector-api_1.6_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec}</version>
+        <artifactId>jboss-connector-api_1.7_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.security.jacc</groupId>
-        <artifactId>jboss-jacc-api_1.4_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec}</version>
+        <artifactId>jboss-jacc-api_1.5_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.servlet</groupId>
-        <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec}</version>
+        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
-        <artifactId>jboss-jsp-api_2.2_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec}</version>
+        <artifactId>jboss-jsp-api_2.3_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
@@ -2427,8 +2427,8 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.transaction</groupId>
-        <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec}</version>
+        <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.ws.rs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@
     <version.javax.enterprise>1.2</version.javax.enterprise>
     <version.javax.inject>1</version.javax.inject>
     <version.javax.jcr>2.0</version.javax.jcr>
-    <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
     <version.javax.mail>1.4.5</version.javax.mail>
     <version.javax.validation>1.1.0.Final</version.javax.validation>
     <version.jaxen>1.1.6</version.jaxen>
@@ -281,17 +280,17 @@
     <version.org.jboss.seam>3.1.0.Final</version.org.jboss.seam>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-8</version.org.jboss.shrinkwrap.descriptors>
     <version.org.jboss.shrinkwrap.resolver>2.2.0</version.org.jboss.shrinkwrap.resolver>
-    <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.1_spec>
-    <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>
-    <version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>
-    <version.org.jboss.spec.javax.interceptor>1.0.1.Final</version.org.jboss.spec.javax.interceptor>
-    <version.org.jboss.spec.javax.jms>1.0.1.Final</version.org.jboss.spec.javax.jms>
-    <version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec>1.0.1.Final</version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec>
-    <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>1.0.3.Final</version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>
-    <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec>
-    <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec>
+    <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
+    <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
+    <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.6.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
+    <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>
+    <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
+    <version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec>1.0.0.Final</version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec>
+    <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>1.0.0.Final</version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>
+    <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
+    <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
     <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.1.2.Final</version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
-    <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec>
+    <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.0_spec>
     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>


### PR DESCRIPTION
 * the artifactIds were changed as well (e.g. servlet-api-3.0
   vs servlet-api-3.1) so this will require fixes in the child
   POMs