### PR TITLE
Rename enforcer execution 'ban-uberjars' to more generic 'ban-blackli…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -448,7 +448,7 @@
           </execution>
 
           <execution>
-            <id>ban-uberjars</id>
+            <id>ban-blacklisted-dependencies</id>
             <goals>
               <goal>enforce</goal>
             </goals>


### PR DESCRIPTION
…sted-dependencies'

 * there may be other types of dependencies user wants to ban
   (like rogue logging deps or non-JBoss Spec jars).  The 'ban-uberjars'
   is bit too specific and looks weird if you use it in child POMs where
   you actually ban non-uberjars. After renaming we can easily reuse
   the enforcer execution without the need to add new one in child POMs.