### PR TITLE
Replace 'org.jboss.as' deps with 'org.wildfly' ones

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1908,57 +1908,7 @@
         <scope>import</scope>
       </dependency>
 
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-arquillian-container-managed</artifactId>
-        <version>${version.org.jboss.as.arquillian}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-arquillian-container-remote</artifactId>
-        <version>${version.org.jboss.as.arquillian}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-arquillian-common</artifactId>
-        <version>${version.org.jboss.as.arquillian}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-arquillian-testenricher-msc</artifactId>
-        <version>${version.org.jboss.as.arquillian}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-arquillian-protocol-jmx</artifactId>
-        <version>${version.org.jboss.as.arquillian}</version>
-      </dependency>
 
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-naming</artifactId>
-        <version>${version.org.jboss.as}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-server</artifactId>
-        <version>${version.org.jboss.as}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-controller</artifactId>
-        <version>${version.org.jboss.as}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-security</artifactId>
-        <version>${version.org.jboss.as}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-weld</artifactId>
-        <version>${version.org.jboss.as}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.jboss.osgi.metadata</groupId>
@@ -2959,6 +2909,59 @@
         <groupId>org.tukaani</groupId>
         <artifactId>xz</artifactId>
         <version>${version.org.tukaani}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-naming</artifactId>
+        <version>${version.org.wildfly}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-security</artifactId>
+        <version>${version.org.wildfly}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-weld</artifactId>
+        <version>${version.org.wildfly}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-common</artifactId>
+        <version>${version.org.wildfly.arquillian}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-container-managed</artifactId>
+        <version>${version.org.wildfly.arquillian}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-container-remote</artifactId>
+        <version>${version.org.wildfly.arquillian}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
+        <version>${version.org.wildfly.arquillian}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-testenricher-msc</artifactId>
+        <version>${version.org.wildfly.arquillian}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-controller</artifactId>
+        <version>${version.org.wildfly.core}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-server</artifactId>
+        <version>${version.org.wildfly.core}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -257,8 +257,6 @@
     <version.org.jboss.arquillian.container.weld>1.0.0.CR5</version.org.jboss.arquillian.container.weld>
     <!-- Important: Selenium version 2.46.0 is the last one supported on Java 6! -->
     <version.org.jboss.arquillian.selenium>2.46.0</version.org.jboss.arquillian.selenium>
-    <version.org.jboss.as.arquillian>7.2.0.Final</version.org.jboss.as.arquillian>
-    <version.org.jboss.as>7.5.6.Final-redhat-2</version.org.jboss.as>
     <version.org.jboss.classfilewriter>1.1.2.Final</version.org.jboss.classfilewriter>
     <version.org.jboss.jboss-common-core>2.5.0.Final</version.org.jboss.jboss-common-core>
     <version.org.jboss.jbossts.jta>4.17.29.Final</version.org.jboss.jbossts.jta>
@@ -344,6 +342,9 @@
     <version.org.timepedia.chronoscope>2.0_jboss</version.org.timepedia.chronoscope>
     <version.org.timepedia.exporter>2.0.10</version.org.timepedia.exporter>
     <version.org.tukaani>1.0</version.org.tukaani>
+    <version.org.wildfly>10.0.0.Final</version.org.wildfly>
+    <version.org.wildfly.arquillian>2.0.0.Final</version.org.wildfly.arquillian>
+    <version.org.wildfly.core>2.0.10.Final</version.org.wildfly.core>
     <version.org.yaml.snakeyaml>1.15</version.org.yaml.snakeyaml>
     <version.postgresql>8.4-702.jdbc4</version.postgresql>
     <version.rhino.js>1.7R2</version.rhino.js>


### PR DESCRIPTION
 * only WildFly 10+ is supported on branch 7.x, so no one
   should be using these old artifacts