### PR TITLE
Upgrade assertj-core from 3.3.0 to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <version.org.apache.xmlbeans>2.6.0</version.org.apache.xmlbeans>
     <version.org.apache.ws.xmlschema>2.2.1</version.org.apache.ws.xmlschema>
     <version.org.apache.xmlgraphics.batik>1.7</version.org.apache.xmlgraphics.batik>
-    <version.org.assertj>3.3.0</version.org.assertj>
+    <version.org.assertj>3.5.2</version.org.assertj>
     <version.org.apache-extras.beanshell>2.0b6</version.org.apache-extras.beanshell>
     <version.org.clojure>1.3.0-alpha5</version.org.clojure>
     <version.org.cobogw.gwt>1.0</version.org.cobogw.gwt>


### PR DESCRIPTION
Version 3.5.2 contains two useful fixes related to Iterator asserts.