### PR TITLE
Upgrade Weld to 2.4.1.Final + Weld API to 2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,8 +294,8 @@
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
     <version.org.jboss.solder>3.2.1.Final</version.org.jboss.solder>
     <version.org.jboss.staxmapper>1.2.0.Final</version.org.jboss.staxmapper>
-    <version.org.jboss.weld.weld>2.3.3.Final</version.org.jboss.weld.weld>
-    <version.org.jboss.weld.weld-api>2.3.SP1</version.org.jboss.weld.weld-api>
+    <version.org.jboss.weld.weld>2.4.1.Final</version.org.jboss.weld.weld>
+    <version.org.jboss.weld.weld-api>2.4.Final</version.org.jboss.weld.weld-api>
     <version.org.jboss.xnio>3.3.6.Final</version.org.jboss.xnio>
     <version.org.jboss.ws.api>1.0.3.Final</version.org.jboss.ws.api>
     <version.org.jboss.ws.spi>3.1.0.Final</version.org.jboss.ws.spi>


### PR DESCRIPTION
These versions will also be used by EAP 7.1 (when it gets released).