### PR TITLE
Upgrade freemarker from 2.3.19 to 2.3.25-incubating

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
     <version.org.eclipse.jetty>9.2.14.v20151106</version.org.eclipse.jetty>
     <version.org.eclipse.jgit>4.4.1.201607150455-r</version.org.eclipse.jgit>
     <version.org.eclipse.sisu>0.3.0.M1</version.org.eclipse.sisu>
-    <version.org.freemarker>2.3.19</version.org.freemarker>
+    <version.org.freemarker>2.3.25-incubating</version.org.freemarker>
     <version.org.glassfish>3.1.2</version.org.glassfish>
     <version.org.gwtbootstrap3>0.9.3</version.org.gwtbootstrap3>
     <version.org.hibernate>5.0.9.Final</version.org.hibernate>


### PR DESCRIPTION
The 'incubating' means the freemarker projects was moved
to Apache foundation and is in incubating period.