### PR TITLE
Upgrade versions of Ant to 1.8.4 and iText to 2.1.7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <version.com.google.protobuf>2.6.0</version.com.google.protobuf>
     <version.com.h2database>1.3.173</version.com.h2database>
     <version.com.jcraft>0.1.50</version.com.jcraft>
-    <version.com.lowagie.itext>2.1.2</version.com.lowagie.itext>
+    <version.com.lowagie.itext>2.1.7</version.com.lowagie.itext>
     <version.com.mchange.c3p0>0.9.2.1</version.com.mchange.c3p0>
     <version.com.miglayout>3.7.4</version.com.miglayout>
     <version.com.smartgwt.smartgwt-skins>2.4</version.com.smartgwt.smartgwt-skins>
@@ -175,7 +175,7 @@
     <version.org.antlr.ST4>4.0.7</version.org.antlr.ST4>
     <version.org.apache.abdera>1.1.3</version.org.apache.abdera>
     <version.org.apache.activemq>5.8.0</version.org.apache.activemq>
-    <version.org.apache.ant>1.8.3</version.org.apache.ant>
+    <version.org.apache.ant>1.8.4</version.org.apache.ant>
     <version.org.apache.aries.blueprint.api>1.0.1</version.org.apache.aries.blueprint.api>
     <version.org.apache.aries.blueprint.noosgi>1.1.1</version.org.apache.aries.blueprint.noosgi>
     <version.org.apache.aries.blueprint.parser>1.4.0</version.org.apache.aries.blueprint.parser>


### PR DESCRIPTION
These new versions are already built from source in Brew.