### PR TITLE
Upgrade Javassist from 3.18.2-GA to 3.20.0-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>
     <version.org.jasypt.jasypt>1.9.1</version.org.jasypt.jasypt>
-    <version.org.javassist>3.18.2-GA</version.org.javassist>
+    <version.org.javassist>3.20.0-GA</version.org.javassist>
     <version.org.jaudiotagger>2.0.3</version.org.jaudiotagger>
     <version.org.jboss.arquillian>1.1.10.Final</version.org.jboss.arquillian>
     <version.org.jboss.arquillian.container.glassfish>1.0.0.CR3</version.org.jboss.arquillian.container.glassfish>


### PR DESCRIPTION
Javassist 3.20.0+ required by Hibernate 5.1.x