### PR TITLE
Upgrade Batik to version 1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <version.org.apache.velocity.velocity-tools>2.0</version.org.apache.velocity.velocity-tools>
     <version.org.apache.xmlbeans>2.6.0</version.org.apache.xmlbeans>
     <version.org.apache.ws.xmlschema>2.2.1</version.org.apache.ws.xmlschema>
-    <version.org.apache.xmlgraphics.batik>1.7</version.org.apache.xmlgraphics.batik>
+    <version.org.apache.xmlgraphics.batik>1.9.1</version.org.apache.xmlgraphics.batik>
     <version.org.assertj>3.5.2</version.org.assertj>
     <version.org.apache-extras.beanshell>2.0b6</version.org.apache-extras.beanshell>
     <version.org.clojure>1.3.0-alpha5</version.org.clojure>


### PR DESCRIPTION
From 1.7 to 1.9 some security issues have been fixed

https://xmlgraphics.apache.org/security.html