### PR TITLE
Upgrade the logback version to 1.2.0 and slf4j version to 1.7.22 for 7.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <version.asm>3.3.1</version.asm>
     <version.ca.uhn.hapi>2.1</version.ca.uhn.hapi>
     <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
-    <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
+    <version.ch.qos.logback>1.2.0</version.ch.qos.logback>
     <version.commons-cli>1.2</version.commons-cli>
     <version.commons-codec>1.10</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>
@@ -332,7 +332,7 @@
     <version.org.rhq>4.8.0</version.org.rhq>
     <!-- Avoid using scannotation in favor of its successor org.reflections -->
     <version.org.scannotation>1.0.3</version.org.scannotation>
-    <version.org.slf4j>1.7.7</version.org.slf4j>
+    <version.org.slf4j>1.7.22</version.org.slf4j>
     <version.org.sonatype.aether>1.13.1</version.org.sonatype.aether>
     <version.org.sonatype.maven>1.2.1</version.org.sonatype.maven>
     <version.org.sonatype.plexus.plexus-cipher>1.7</version.org.sonatype.plexus.plexus-cipher>


### PR DESCRIPTION
*Upgrade the logback version from 1.1.3 to 1.2.3
    according to CVE-2017-5929 RHBPMS-4660 bug is fixed in 1.2.0, but the latest version is 1.2.3
 *Upgrade the slf4j version from 1.7.7 to 1.7.25 to keep up with the logback 1.2.3
