### PR TITLE
changed development version to -SNAPSHOT

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
-    <version>8.0.0.CR1</version>
+    <version>8.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <!-- major.minor.micro.Beta[n] -->
   <!-- major.minor.micro.CR[n] -->
   <!-- major.minor.micro.Final -->
-  <version>8.0.0.CR1</version>
+  <version>8.0.0-SNAPSHOT</version>
 
   <name>JBoss Integration Platform Parent</name>
   <description>
@@ -71,7 +71,7 @@
     <connection>scm:git:git@github.com:jboss-integration/jboss-integration-platform-bom.git</connection>
     <developerConnection>scm:git:git@github.com:jboss-integration/jboss-integration-platform-bom.git</developerConnection>
     <url>https://github.com/jboss-integration/jboss-integration-platform-bom</url>
-    <tag>8.0.0.CR1</tag>
+    <tag>8.0.0-SNAPSHOT</tag>
   </scm>
   <ciManagement>
     <system>hudson</system>


### PR DESCRIPTION
@psiroky I don't know when this happened - but on master we need t have 8.0.0-SNAPSHOT. It seems to me that I tried to do a new release CR1 - but this already exists, yepp. So I was alerted. I think during the release procedure this happens - but I don't know when and I know that I didn't finish it as I was aterted about an already existing version. Maybe this happened the last time?  
Could you please approve this and merge this as it is required for BxMS 7.0.0.DR1 (master - GA) to align to EAP7.1, and jboss-ip-bom 8.0.0.CR1 has this alignment partially, so I will release a new ip-bom 8.0.0.CR2