### PR TITLE
JBPM-6274: fix of managed artifactId for batik-extension

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1478,6 +1478,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-extension</artifactId>
+        <version>${version.org.apache.xmlgraphics.batik}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-xml</artifactId>
         <version>${version.org.apache.xmlgraphics.batik}</version>
       </dependency>


### PR DESCRIPTION
fixing wrong definition of batik-extension see error from CI test of https://github.com/kiegroup/jbpm-designer/pull/700