### PR TITLE
JBPM-6274: continuation of batik upgrade

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -1442,6 +1442,12 @@
 
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>xmlgraphics-commons</artifactId>
+        <version>${version.org.apache.xmlgraphics.commons}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-dom</artifactId>
         <version>${version.org.apache.xmlgraphics.batik}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@
     <version.org.apache.xmlbeans>2.6.0</version.org.apache.xmlbeans>
     <version.org.apache.ws.xmlschema>2.2.1</version.org.apache.ws.xmlschema>
     <version.org.apache.xmlgraphics.batik>1.9.1</version.org.apache.xmlgraphics.batik>
+    <version.org.apache.xmlgraphics.commons>2.2</version.org.apache.xmlgraphics.commons>
     <version.org.assertj>3.8.0</version.org.assertj>
     <version.org.apache-extras.beanshell>2.0b6</version.org.apache-extras.beanshell>
     <version.org.clojure>1.3.0-alpha5</version.org.clojure>


### PR DESCRIPTION
move of xmlgraphics-commons to IP-BOM and upgrade to 2.2

This resulted from discussion in https://github.com/kiegroup/jbpm-designer/pull/700#issuecomment-346700994 and https://github.com/kiegroup/jbpm-designer/pull/700#issuecomment-346700994 comments. 