### PR TITLE
JBPM-6102: Upgrade lienzo artifacts to version 2.0.293-RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,8 @@
     <version.commons-pool>1.6</version.commons-pool>
     <version.commons-io>2.5</version.commons-io>
     <version.commons-vfs>1.0</version.commons-vfs>
-    <version.com.ahome-it.lienzo-core>2.0.292-RELEASE</version.com.ahome-it.lienzo-core>
-    <version.com.ahome-it.lienzo-tests>2.0.292-RELEASE</version.com.ahome-it.lienzo-tests>
+    <version.com.ahome-it.lienzo-core>2.0.294-RELEASE</version.com.ahome-it.lienzo-core>
+    <version.com.ahome-it.lienzo-tests>2.0.294-RELEASE</version.com.ahome-it.lienzo-tests>
     <version.com.ahome-it.lienzo.tooling.nativetools>1.0.195-RELEASE</version.com.ahome-it.lienzo.tooling.nativetools>
     <version.com.ahome-it.lienzo.tooling.common>1.0.190-RELEASE</version.com.ahome-it.lienzo.tooling.common>
     <version.com.allen-sauer.gwt.dnd>3.1.2</version.com.allen-sauer.gwt.dnd>


### PR DESCRIPTION
See [JBPM-6102](https://issues.jboss.org/browse/JBPM-6102)
**Note**: please merge together or after these other ones: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/629 and https://github.com/kiegroup/kie-wb-common/pull/1309.