### PR TITLE
Increase version of PowerMock.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
     <version.org.owasp.encoder>1.2</version.org.owasp.encoder>
     <version.org.picketbox>5.0.2.Final</version.org.picketbox>
     <version.org.picketlink>2.5.5.SP8</version.org.picketlink>
-    <version.org.powermock>1.6.3</version.org.powermock>
+    <version.org.powermock>1.7.3</version.org.powermock>
     <version.org.python>2.5.3</version.org.python>
     <version.org.quartz-scheduler>1.8.5</version.org.quartz-scheduler>
     <version.org.reflections>0.9.11</version.org.reflections>


### PR DESCRIPTION
This PR increases the version of PowerMock. This change is necessary in order to be able to use JaCoCo in AppFormer. The older version causes the `JAASAuthenticationServiceTest` test in the `org.uberfire.backend.server.security` package to fail.

The following PR adds JaCoCo to AppFormer: https://github.com/kiegroup/appformer/pull/126.
  