### PR TITLE
Upgrade ShrinkWrap Resolver to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
     <version.org.jboss.seam.security>3.2.0.Final</version.org.jboss.seam.security>
     <version.org.jboss.seam>3.1.0.Final</version.org.jboss.seam>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-8</version.org.jboss.shrinkwrap.descriptors>
-    <version.org.jboss.shrinkwrap.resolver>2.2.0</version.org.jboss.shrinkwrap.resolver>
+    <version.org.jboss.shrinkwrap.resolver>3.1.0</version.org.jboss.shrinkwrap.resolver>
     <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
     <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
     <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.9.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>


### PR DESCRIPTION
Hi, @mareknovotny,

here is the upgrade of ShrinkWrap resolver to the version 3.1.0 which uses newest Maven Artifact Resolver instead of Aether and fixes issues with downloading optional dependencies when generating archives using Arquillian.

Thanks.