### PR TITLE
JBPM-6794 - updating eclipse.bpmn2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
     <version.org.codehaus.woodstox>4.4.1</version.org.codehaus.woodstox>
     <version.org.easytesting.fest>2.0M6</version.org.easytesting.fest>
     <version.org.easymock>3.0</version.org.easymock>
-    <version.org.eclipse.bpmn2>0.7.6-jboss</version.org.eclipse.bpmn2>
+    <version.org.eclipse.bpmn2>0.8.2-jboss</version.org.eclipse.bpmn2>
     <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
     <version.org.eclipse.emf>2.6.0.v20100614-1136</version.org.eclipse.emf>
     <version.org.eclipse.emf.ecore.xmi>2.5.0.v20100521-1846</version.org.eclipse.emf.ecore.xmi>


### PR DESCRIPTION
I updated the version of org.eclipse.bpmn2. this is to use the new version.