### PR TITLE
Updated protobuf to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <version.org.google.gwt.visualization>1.0.2</version.org.google.gwt.visualization>
     <version.com.google.javascript.closure-compiler>r1741</version.com.google.javascript.closure-compiler>
     <version.com.google.jsinterop>1.0.1</version.com.google.jsinterop>
-    <version.com.google.protobuf>2.6.1</version.com.google.protobuf>
+    <version.com.google.protobuf>3.6.1</version.com.google.protobuf>
     <version.com.h2database>1.3.173</version.com.h2database>
     <version.com.jcraft>0.1.54</version.com.jcraft>
     <version.com.lowagie.itext>2.1.7</version.com.lowagie.itext>


### PR DESCRIPTION
In Fedora is much easier to have protobufc 3.6 installed than 2.6 and from my experiments drools works without problem with that. I hope that JBPM does that also