### PR TITLE
Align JAXB and JAXWS APIs with Wildfly

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -514,8 +514,8 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.xml.bind</groupId>
-        <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec}</version>
+        <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec}</version>
       </dependency>
 
       <dependency>
@@ -2566,8 +2566,8 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.xml.ws</groupId>
-        <artifactId>jboss-jaxws-api_2.2_spec</artifactId>
-        <version>${version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec}</version>
+        <artifactId>jboss-jaxws-api_2.3_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -298,8 +298,8 @@
     <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.1.3.Final</version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
     <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.0.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.0_spec>
-    <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.4.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
-    <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
+    <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
+    <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
     <version.org.jboss.solder>3.2.1.Final</version.org.jboss.solder>
     <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
     <version.org.jboss.weld.weld>2.4.1.Final</version.org.jboss.weld.weld>


### PR DESCRIPTION
Hi @mbiarnes @mareknovotny,

here is the PR we discussed which aligns jaxws-api and jaxb-api with Wildfly. After ip-bom of version 8.4.0.Final is released, we can also merge PRs which are waiting across kiegroup repositories.

Thanks for help!
