### PR TITLE
inserted version for org.hibernate.search.modules

### DIFF
--- a/ip-bom/pom.xml
+++ b/ip-bom/pom.xml
@@ -2014,13 +2014,6 @@
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-search-modules</artifactId>
-        <version>${version.org.hibernate.search}</version>
-        <classifier>wildfly-10-dist</classifier>
-        <type>zip</type>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate</groupId>
         <artifactId>hibernate-jpamodelgen</artifactId>
         <version>${version.org.hibernate}</version>
       </dependency>


### PR DESCRIPTION
had to add a new version for the dependency
org.hibernate:hibernate-search-modules since it took before the version of org.hibernate.search and this artifact doesn't exist with this version 